### PR TITLE
Add product images and links for highlights

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -326,63 +326,76 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
   <!-- Produkte (Beispiele) -->
   <section class="section">
     <div class="container">
-      <h2>Neu eingetroffen</h2>
-      <p class="lead">Sorgfältig ausgewählte Modelle von verifizierten Händlern.</p>
+        <h2>Highlights &amp; Bestseller</h2>
+        <p class="lead">Sorgfältig ausgewählte Modelle von verifizierten Händlern.</p>
 
-      <div class="grid" style="margin-top:14px;">
-        <!-- Card 1 -->
-        <article class="card col-3">
-          <a href="/produkte/nova-1" aria-label="Zum Produkt Nova 1">
-            <div class="card__img"><img src="/assets/images/products/p1.jpg" alt="Sneaker Nova 1 schwarz"/></div>
-            <div class="card__body">
-              <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
-                <h3 style="margin:0; font-size:16px;">Nova 1</h3>
-                <span class="price">129,00 €</span>
+        <div class="grid" style="margin-top:14px;">
+          <!-- Produkt 1 -->
+          <article class="card col-3">
+            <a href="produkt-detail1.html" aria-label="Zum Produkt 1">
+              <div class="card__img"><img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Produkt 1"/></div>
+              <div class="card__body">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                  <h3 style="margin:0; font-size:16px;">Produkt 1</h3>
+                  <span class="price">129,00&nbsp;€</span>
+                </div>
+                <div class="meta">Lieferzeit: 2–4 Werktage</div>
               </div>
-              <div class="meta">Lieferzeit: 2–4 Werktage</div>
-            </div>
-          </a>
-        </article>
-        <!-- Card 2 -->
-        <article class="card col-3">
-          <a href="/produkte/air-lite" aria-label="Zum Produkt Air Lite">
-            <div class="card__img"><img src="/assets/images/products/p2.jpg" alt="Sneaker Air Lite weiß"/></div>
-            <div class="card__body">
-              <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
-                <h3 style="margin:0; font-size:16px;">Air Lite</h3>
-                <span class="price">149,00 €</span>
+            </a>
+          </article>
+          <!-- Produkt 2 -->
+          <article class="card col-3">
+            <a href="produkt-detail2.html" aria-label="Zum Produkt 2">
+              <div class="card__img"><img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Produkt 2"/></div>
+              <div class="card__body">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                  <h3 style="margin:0; font-size:16px;">Produkt 2</h3>
+                  <span class="price">149,00&nbsp;€</span>
+                </div>
+                <div class="meta">Kostenloser Rückversand</div>
               </div>
-              <div class="meta">Kostenloser Rückversand</div>
-            </div>
-          </a>
-        </article>
-        <!-- Card 3 -->
-        <article class="card col-3">
-          <a href="/produkte/runner-pro" aria-label="Zum Produkt Runner Pro">
-            <div class="card__img"><img src="/assets/images/products/p3.jpg" alt="Sneaker Runner Pro grau"/></div>
-            <div class="card__body">
-              <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
-                <h3 style="margin:0; font-size:16px;">Runner Pro</h3>
-                <span class="price">119,00 €</span>
+            </a>
+          </article>
+          <!-- Produkt 3 -->
+          <article class="card col-3">
+            <a href="produkt-detail3.html" aria-label="Zum Produkt 3">
+              <div class="card__img"><img src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg" alt="Produkt 3"/></div>
+              <div class="card__body">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                  <h3 style="margin:0; font-size:16px;">Produkt 3</h3>
+                  <span class="price">119,00&nbsp;€</span>
+                </div>
+                <div class="meta">Nur noch wenige verfügbar</div>
               </div>
-              <div class="meta">Nur noch wenige verfügbar</div>
-            </div>
-          </a>
-        </article>
-        <!-- Card 4 -->
-        <article class="card col-3">
-          <a href="/produkte/urban-x" aria-label="Zum Produkt Urban X">
-            <div class="card__img"><img src="/assets/images/products/p4.jpg" alt="Sneaker Urban X blau"/></div>
-            <div class="card__body">
-              <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
-                <h3 style="margin:0; font-size:16px;">Urban X</h3>
-                <span class="price">139,00 €</span>
+            </a>
+          </article>
+          <!-- Produkt 4 -->
+          <article class="card col-3">
+            <a href="produkt-detail4.html" aria-label="Zum Produkt 4">
+              <div class="card__img"><img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Produkt 4"/></div>
+              <div class="card__body">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                  <h3 style="margin:0; font-size:16px;">Produkt 4</h3>
+                  <span class="price">139,00&nbsp;€</span>
+                </div>
+                <div class="meta">Versand aus DE</div>
               </div>
-              <div class="meta">Versand aus DE</div>
-            </div>
-          </a>
-        </article>
-      </div>
+            </a>
+          </article>
+          <!-- Produkt 5 -->
+          <article class="card col-3">
+            <a href="produkt-detail5.html" aria-label="Zum Produkt 5">
+              <div class="card__img"><img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Produkt 5"/></div>
+              <div class="card__body">
+                <div style="display:flex; justify-content:space-between; align-items:center; gap:8px;">
+                  <h3 style="margin:0; font-size:16px;">Produkt 5</h3>
+                  <span class="price">99,00&nbsp;€</span>
+                </div>
+                <div class="meta">Schneller Versand</div>
+              </div>
+            </a>
+          </article>
+        </div>
 
       <div style="margin-top:16px; display:flex; gap:10px;">
         <a class="btn" href="/products.html">Alle Produkte</a>


### PR DESCRIPTION
## Summary
- replace placeholder highlight section with five product cards
- link cards to their respective product-detail pages
- include actual product images from assets

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ad094ee7348321acbc946ee97b78f9