### PR TITLE
Populate product cards with real names and images

### DIFF
--- a/frontend/products.html
+++ b/frontend/products.html
@@ -337,14 +337,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 <div class="grid" style="margin-top:14px">
   <!-- Produkt 1 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail1.html" aria-label="Zum Produkt 1">
+    <a href="produkt-detail1.html" aria-label="Zum Beurer BR 60 Insektenstichheiler">
       <div class="card__img">
-        <img src="/assets/images/products/p1.jpg" alt="Produkt 1" loading="lazy">
+        <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler" loading="lazy">
         <span class="label label--low">Nur 3 übrig</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 1</h3>
+          <h3>Beurer BR 60 Insektenstichheiler</h3>
           <span class="price">129,00 €</span>
         </div>
         <div class="stars" aria-label="4.7 von 5">
@@ -358,14 +358,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 2 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail2.html" aria-label="Zum Produkt 2">
+    <a href="produkt-detail2.html" aria-label="Zum Sanotact Elektrolyte Plus (20 Beutel)">
       <div class="card__img">
-        <img src="/assets/images/products/p2.jpg" alt="Produkt 2" loading="lazy">
+        <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel)" loading="lazy">
         <span class="label">Bestseller</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 2</h3>
+          <h3>Sanotact Elektrolyte Plus (20 Beutel)</h3>
           <span class="price">149,00 €</span>
         </div>
         <div class="stars" aria-label="4.9 von 5">
@@ -379,14 +379,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 3 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail3.html" aria-label="Zum Produkt 3">
+    <a href="produkt-detail3.html" aria-label="Zum Bienengift Gelenkcreme">
       <div class="card__img">
-        <img src="/assets/images/products/p3.jpg" alt="Produkt 3" loading="lazy">
+        <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme" loading="lazy">
         <span class="label">Heute versandfertig</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 3</h3>
+          <h3>Bienengift Gelenkcreme</h3>
           <span class="price">119,00 €</span>
         </div>
         <div class="stars" aria-label="4.6 von 5">
@@ -400,14 +400,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 4 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail4.html" aria-label="Zum Produkt 4">
+    <a href="produkt-detail4.html" aria-label="Zum Autan Multi Insect Pumpspray">
       <div class="card__img">
-        <img src="/assets/images/products/p4.jpg" alt="Produkt 4" loading="lazy">
+        <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray" loading="lazy">
         <span class="label label--low">Nur 2 übrig</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 4</h3>
+          <h3>Autan Multi Insect Pumpspray</h3>
           <span class="price">139,00 €</span>
         </div>
         <div class="stars" aria-label="4.7 von 5">
@@ -421,14 +421,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 5 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail5.html" aria-label="Zum Produkt 5">
+    <a href="produkt-detail5.html" aria-label="Zum Beurer EM 49 Digital TENSEMS">
       <div class="card__img">
-        <img src="/assets/images/products/p5.jpg" alt="Produkt 5" loading="lazy">
+        <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS" loading="lazy">
         <span class="label">Neu</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 5</h3>
+          <h3>Beurer EM 49 Digital TENSEMS</h3>
           <span class="price">89,00 €</span>
         </div>
         <div class="stars" aria-label="4.5 von 5">
@@ -442,13 +442,13 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 6 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail6.html" aria-label="Zum Produkt 6">
+    <a href="produkt-detail6.html" aria-label="Zum Abtei Venen Aktiv Balsam">
       <div class="card__img">
-        <img src="/assets/images/products/p6.jpg" alt="Produkt 6" loading="lazy">
+        <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Abtei Venen Aktiv Balsam" loading="lazy">
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 6</h3>
+          <h3>Abtei Venen Aktiv Balsam</h3>
           <span class="price">159,00 €</span>
         </div>
         <div class="stars" aria-label="4.8 von 5">
@@ -462,14 +462,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 7 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail7.html" aria-label="Zum Produkt 7">
+    <a href="produkt-detail7.html" aria-label="Zum Ashwagandha Kapseln hochdosiert 120x - 600 mg">
       <div class="card__img">
-        <img src="/assets/images/products/p7.jpg" alt="Produkt 7" loading="lazy">
+        <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg" loading="lazy">
         <span class="label label--low">Nur 1 übrig</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 7</h3>
+          <h3>Ashwagandha Kapseln hochdosiert 120x - 600 mg</h3>
           <span class="price">129,00 €</span>
         </div>
         <div class="stars" aria-label="4.7 von 5">
@@ -483,14 +483,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 8 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail8.html" aria-label="Zum Produkt 8">
+    <a href="produkt-detail8.html" aria-label="Zum AUDISPRAY Ultra">
       <div class="card__img">
-        <img src="/assets/images/products/p8.jpg" alt="Produkt 8" loading="lazy">
+        <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra" loading="lazy">
         <span class="label">Angebot</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 8</h3>
+          <h3>AUDISPRAY Ultra</h3>
           <span class="price">99,00 €</span>
         </div>
         <div class="stars" aria-label="4.4 von 5">
@@ -504,13 +504,13 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 9 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail9.html" aria-label="Zum Produkt 9">
+    <a href="produkt-detail9.html" aria-label="Zum Bauerfeind ViscoSpot Fersenkisse">
       <div class="card__img">
-        <img src="/assets/images/products/p9.jpg" alt="Produkt 9" loading="lazy">
+        <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse" loading="lazy">
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 9</h3>
+          <h3>Bauerfeind ViscoSpot Fersenkisse</h3>
           <span class="price">179,00 €</span>
         </div>
         <div class="stars" aria-label="4.8 von 5">
@@ -524,14 +524,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 10 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail10.html" aria-label="Zum Produkt 10">
+    <a href="produkt-detail10.html" aria-label="Zum Behrend Warzenmittel für Hand & Fuß">
       <div class="card__img">
-        <img src="/assets/images/products/p10.jpg" alt="Produkt 10" loading="lazy">
+        <img src="/assets/images/products/Produkt10/videoframe_22737.png" alt="Behrend Warzenmittel für Hand & Fuß" loading="lazy">
         <span class="label">Bestseller</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 10</h3>
+          <h3>Behrend Warzenmittel für Hand & Fuß</h3>
           <span class="price">109,00 €</span>
         </div>
         <div class="stars" aria-label="4.6 von 5">
@@ -545,14 +545,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 11 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail11.html" aria-label="Zum Produkt 11">
+    <a href="produkt-detail11.html" aria-label="Zum Fußmassagerolle für Plantarfasziitis">
       <div class="card__img">
-        <img src="/assets/images/products/p11.jpg" alt="Produkt 11" loading="lazy">
+        <img src="/assets/images/products/Produkt11/611TpwuiETL._AC_SL1500_.jpg" alt="Fußmassagerolle für Plantarfasziitis" loading="lazy">
         <span class="label label--low">Nur wenige da</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 11</h3>
+          <h3>Fußmassagerolle für Plantarfasziitis</h3>
           <span class="price">149,00 €</span>
         </div>
         <div class="stars" aria-label="4.7 von 5">
@@ -566,14 +566,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 12 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail12.html" aria-label="Zum Produkt 12">
+    <a href="produkt-detail12.html" aria-label="Zum Glückstoff® Orthopädisches Kissen">
       <div class="card__img">
-        <img src="/assets/images/products/p12.jpg" alt="Produkt 12" loading="lazy">
+        <img src="/assets/images/products/Produkt12/818Xtkh3sfL._AC_SL1500_.jpg" alt="Glückstoff® Orthopädisches Kissen" loading="lazy">
         <span class="label">Empfohlen</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 12</h3>
+          <h3>Glückstoff® Orthopädisches Kissen</h3>
           <span class="price">119,00 €</span>
         </div>
         <div class="stars" aria-label="4.5 von 5">
@@ -587,14 +587,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 13 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail13.html" aria-label="Zum Produkt 13">
+    <a href="produkt-detail13.html" aria-label="Zum health Press">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="Produkt 13" loading="lazy">
+        <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="health Press" loading="lazy">
         <span class="label">Neu</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 13</h3>
+          <h3>health Press</h3>
           <span class="price">89,00 €</span>
         </div>
         <div class="stars" aria-label="4.6 von 5">
@@ -608,14 +608,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 14 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail14.html" aria-label="Zum Produkt 14">
+    <a href="produkt-detail14.html" aria-label="Zum heat it - Insektenstichheiler für dein Smartphone">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="Produkt 14" loading="lazy">
+        <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="heat it - Insektenstichheiler für dein Smartphone" loading="lazy">
         <span class="label">Bestseller</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 14</h3>
+          <h3>heat it - Insektenstichheiler für dein Smartphone</h3>
           <span class="price">79,00 €</span>
         </div>
         <div class="stars" aria-label="4.8 von 5">
@@ -629,14 +629,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 15 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail15.html" aria-label="Zum Produkt 15">
+    <a href="produkt-detail15.html" aria-label="Zum Letitwell Heizkissen">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Produkt 15" loading="lazy">
+        <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Letitwell Heizkissen" loading="lazy">
         <span class="label label--low">Sale</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 15</h3>
+          <h3>Letitwell Heizkissen</h3>
           <span class="price">99,00 €</span>
         </div>
         <div class="stars" aria-label="4.5 von 5">
@@ -650,14 +650,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 16 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail16.html" aria-label="Zum Produkt 16">
+    <a href="produkt-detail16.html" aria-label="Zum SANOHRA fly">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="Produkt 16" loading="lazy">
+        <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="SANOHRA fly" loading="lazy">
         <span class="label">Beliebt</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 16</h3>
+          <h3>SANOHRA fly</h3>
           <span class="price">109,00 €</span>
         </div>
         <div class="stars" aria-label="4.7 von 5">
@@ -671,14 +671,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 17 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail17.html" aria-label="Zum Produkt 17">
+    <a href="produkt-detail17.html" aria-label="Zum SOS Hämorrhoiden-Salbe">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="Produkt 17" loading="lazy">
+        <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="SOS Hämorrhoiden-Salbe" loading="lazy">
         <span class="label">Neu</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 17</h3>
+          <h3>SOS Hämorrhoiden-Salbe</h3>
           <span class="price">59,00 €</span>
         </div>
         <div class="stars" aria-label="4.3 von 5">
@@ -692,14 +692,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 18 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail18.html" aria-label="Zum Produkt 18">
+    <a href="produkt-detail18.html" aria-label="Zum SOS Mund-Heil-Gel">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="Produkt 18" loading="lazy">
+        <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="SOS Mund-Heil-Gel" loading="lazy">
         <span class="label">Empfohlen</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 18</h3>
+          <h3>SOS Mund-Heil-Gel</h3>
           <span class="price">139,00 €</span>
         </div>
         <div class="stars" aria-label="4.9 von 5">
@@ -713,14 +713,14 @@ footer.site-footer{ margin-top: 42px; border-top:1px solid rgba(255,255,255,.06)
 
   <!-- Produkt 19 -->
   <article class="card col-3 card--product">
-    <a href="produkt-detail19.html" aria-label="Zum Produkt 19">
+    <a href="produkt-detail19.html" aria-label="Zum TerraTherm Wärmepflaster Rücken">
       <div class="card__img">
-        <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="Produkt 19" loading="lazy">
+        <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="TerraTherm Wärmepflaster Rücken" loading="lazy">
         <span class="label">Top Wahl</span>
       </div>
       <div class="card__body">
         <div class="row">
-          <h3>Produkt 19</h3>
+          <h3>TerraTherm Wärmepflaster Rücken</h3>
           <span class="price">149,00 €</span>
         </div>
         <div class="stars" aria-label="4.4 von 5">


### PR DESCRIPTION
## Summary
- Fill products grid with actual product names from `ProduktNamen` folders
- Link each card to corresponding product images under `assets/images/products/Produkt<n>/`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf66dbaa48321b6b7c35a7295fa36