### PR TITLE
Add product-specific images for product detail pages 1–12

### DIFF
--- a/frontend/produkt-detail1.html
+++ b/frontend/produkt-detail1.html
@@ -323,14 +323,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p1.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Produktbild: Produkt 1" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p1.jpg" alt="Ansicht 1" data-src="/assets/images/products/p1.jpg">
-            <img src="/assets/images/products/p1b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p1b.jpg">
-            <img src="/assets/images/products/p1c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p1c.jpg">
-            <img src="/assets/images/products/p1d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p1d.jpg">
-            <img src="/assets/images/products/p1e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p1e.jpg">
+            <img src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 1" data-src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 2" data-src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 3" data-src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 4" data-src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail10.html
+++ b/frontend/produkt-detail10.html
@@ -324,14 +324,9 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p10.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt10/videoframe_22737.png" alt="Produktbild: Produkt 10" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p10.jpg" alt="Ansicht 1" data-src="/assets/images/products/p10.jpg">
-            <img src="/assets/images/products/p10b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p10b.jpg">
-            <img src="/assets/images/products/p10c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p10c.jpg">
-            <img src="/assets/images/products/p10d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p10d.jpg">
-            <img src="/assets/images/products/p10e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p10e.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail11.html
+++ b/frontend/produkt-detail11.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p11.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt11/611TpwuiETL._AC_SL1500_.jpg" alt="Produktbild: Produkt 11" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p11.jpg" alt="Ansicht 1" data-src="/assets/images/products/p11.jpg">
-            <img src="/assets/images/products/p11b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p11b.jpg">
-            <img src="/assets/images/products/p11c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p11c.jpg">
-            <img src="/assets/images/products/p11d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p11d.jpg">
-            <img src="/assets/images/products/p11e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p11e.jpg">
+            <img src="/assets/images/products/Produkt11/71+eq0Q1HiL._AC_SL1500_.jpg" alt="Produkt 11 – Ansicht 1" data-src="/assets/images/products/Produkt11/71+eq0Q1HiL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt11/712wusqd8mL._AC_SL1500_.jpg" alt="Produkt 11 – Ansicht 2" data-src="/assets/images/products/Produkt11/712wusqd8mL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt11/71MMDTe-y4L._AC_SL1500_.jpg" alt="Produkt 11 – Ansicht 3" data-src="/assets/images/products/Produkt11/71MMDTe-y4L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt11/71QslJoYRXL._AC_SL1500_.jpg" alt="Produkt 11 – Ansicht 4" data-src="/assets/images/products/Produkt11/71QslJoYRXL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail12.html
+++ b/frontend/produkt-detail12.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p12.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt12/818Xtkh3sfL._AC_SL1500_.jpg" alt="Produktbild: Produkt 12" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p12.jpg" alt="Ansicht 1" data-src="/assets/images/products/p12.jpg">
-            <img src="/assets/images/products/p12b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p12b.jpg">
-            <img src="/assets/images/products/p12c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p12c.jpg">
-            <img src="/assets/images/products/p12d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p12d.jpg">
-            <img src="/assets/images/products/p12e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p12e.jpg">
+            <img src="/assets/images/products/Produkt12/819aVajp0WL._AC_SL1500_.jpg" alt="Produkt 12 – Ansicht 1" data-src="/assets/images/products/Produkt12/819aVajp0WL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt12/81V+BKcspnL._AC_SL1500_.jpg" alt="Produkt 12 – Ansicht 2" data-src="/assets/images/products/Produkt12/81V+BKcspnL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt12/81ukq1y0CML._AC_SL1500_.jpg" alt="Produkt 12 – Ansicht 3" data-src="/assets/images/products/Produkt12/81ukq1y0CML._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt12/81xBcWBGojL._AC_SL1500_.jpg" alt="Produkt 12 – Ansicht 4" data-src="/assets/images/products/Produkt12/81xBcWBGojL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail2.html
+++ b/frontend/produkt-detail2.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p2.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Produktbild: Produkt 2" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p2.jpg" alt="Ansicht 1" data-src="/assets/images/products/p2.jpg">
-            <img src="/assets/images/products/p2b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p2b.jpg">
-            <img src="/assets/images/products/p2c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p2c.jpg">
-            <img src="/assets/images/products/p2d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p2d.jpg">
-            <img src="/assets/images/products/p2e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p2e.jpg">
+            <img src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 1" data-src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 2" data-src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 3" data-src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 4" data-src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail3.html
+++ b/frontend/produkt-detail3.html
@@ -323,14 +323,11 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p3.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Produktbild: Produkt 3" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p3.jpg" alt="Ansicht 1" data-src="/assets/images/products/p3.jpg">
-            <img src="/assets/images/products/p3b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p3b.jpg">
-            <img src="/assets/images/products/p3c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p3c.jpg">
-            <img src="/assets/images/products/p3d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p3d.jpg">
-            <img src="/assets/images/products/p3e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p3e.jpg">
+            <img src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg" alt="Produkt 3 – Ansicht 1" data-src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg" alt="Produkt 3 – Ansicht 2" data-src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail4.html
+++ b/frontend/produkt-detail4.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p4.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Produktbild: Produkt 4" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p4.jpg" alt="Ansicht 1" data-src="/assets/images/products/p4.jpg">
-            <img src="/assets/images/products/p4b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p4b.jpg">
-            <img src="/assets/images/products/p4c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p4c.jpg">
-            <img src="/assets/images/products/p4d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p4d.jpg">
-            <img src="/assets/images/products/p4e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p4e.jpg">
+            <img src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 1" data-src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 2" data-src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 3" data-src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 4" data-src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail5.html
+++ b/frontend/produkt-detail5.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p5.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Produktbild: Produkt 5" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p5.jpg" alt="Ansicht 1" data-src="/assets/images/products/p5.jpg">
-            <img src="/assets/images/products/p5b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p5b.jpg">
-            <img src="/assets/images/products/p5c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p5c.jpg">
-            <img src="/assets/images/products/p5d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p5d.jpg">
-            <img src="/assets/images/products/p5e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p5e.jpg">
+            <img src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 1" data-src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 2" data-src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 3" data-src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 4" data-src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail6.html
+++ b/frontend/produkt-detail6.html
@@ -324,14 +324,12 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p6.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Produktbild: Produkt 6" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p6.jpg" alt="Ansicht 1" data-src="/assets/images/products/p6.jpg">
-            <img src="/assets/images/products/p6b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p6b.jpg">
-            <img src="/assets/images/products/p6c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p6c.jpg">
-            <img src="/assets/images/products/p6d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p6d.jpg">
-            <img src="/assets/images/products/p6e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p6e.jpg">
+            <img src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg" alt="Produkt 6 – Ansicht 1" data-src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg" alt="Produkt 6 – Ansicht 2" data-src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt6/videoframe_31470.png" alt="Produkt 6 – Ansicht 3" data-src="/assets/images/products/Produkt6/videoframe_31470.png">
           </div>
         </aside>
 

--- a/frontend/produkt-detail7.html
+++ b/frontend/produkt-detail7.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p7.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Produktbild: Produkt 7" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p7.jpg" alt="Ansicht 1" data-src="/assets/images/products/p7.jpg">
-            <img src="/assets/images/products/p7b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p7b.jpg">
-            <img src="/assets/images/products/p7c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p7c.jpg">
-            <img src="/assets/images/products/p7d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p7d.jpg">
-            <img src="/assets/images/products/p7e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p7e.jpg">
+            <img src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 1" data-src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 2" data-src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 3" data-src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 4" data-src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail8.html
+++ b/frontend/produkt-detail8.html
@@ -324,14 +324,13 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p8.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="Produktbild: Produkt 8" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p8.jpg" alt="Ansicht 1" data-src="/assets/images/products/p8.jpg">
-            <img src="/assets/images/products/p8b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p8b.jpg">
-            <img src="/assets/images/products/p8c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p8c.jpg">
-            <img src="/assets/images/products/p8d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p8d.jpg">
-            <img src="/assets/images/products/p8e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p8e.jpg">
+            <img src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 1" data-src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 2" data-src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 3" data-src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 4" data-src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg">
           </div>
         </aside>
 

--- a/frontend/produkt-detail9.html
+++ b/frontend/produkt-detail9.html
@@ -324,14 +324,10 @@
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p9.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Produktbild: Produkt 9" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/p9.jpg" alt="Ansicht 1" data-src="/assets/images/products/p9.jpg">
-            <img src="/assets/images/products/p9b.jpg" alt="Ansicht 2" data-src="/assets/images/products/p9b.jpg">
-            <img src="/assets/images/products/p9c.jpg" alt="Ansicht 3" data-src="/assets/images/products/p9c.jpg">
-            <img src="/assets/images/products/p9d.jpg" alt="Ansicht 4" data-src="/assets/images/products/p9d.jpg">
-            <img src="/assets/images/products/p9e.jpg" alt="Ansicht 5" data-src="/assets/images/products/p9e.jpg">
+            <img src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg" alt="Produkt 9 – Ansicht 1" data-src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg">
           </div>
         </aside>
 


### PR DESCRIPTION
## Summary
- Display hero image and up to four thumbnails from each product's asset folder on produkt-detail1–12 pages
- Provide descriptive alt text using each product's name

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68adf0af825c83219d4b331bcbdecaa5