### PR TITLE
Populate product pages with real product data

### DIFF
--- a/frontend/produkt-detail1.html
+++ b/frontend/produkt-detail1.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Beurer BR 60 Insektenstichheiler | DropNGo</title>
+  <meta name="description" content="Beurer BR 60 Insektenstichheiler – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Beurer BR 60 Insektenstichheiler | DropNGo" />
+<meta property="og:description" content="Beurer BR 60 Insektenstichheiler – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail1.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -337,10 +337,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
+      <strong id="scName">Beurer BR 60 Insektenstichheiler</strong>
       <span class="price">129,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4mxEW25" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -349,27 +349,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Beurer BR 60 Insektenstichheiler</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Produktbild: Produkt 1" id="heroImg">
+            <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 1" data-src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 2" data-src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 3" data-src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg" alt="Produkt 1 – Ansicht 4" data-src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler – Ansicht 1" data-src="/assets/images/products/Produkt1/71PgWY3iEFL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler – Ansicht 2" data-src="/assets/images/products/Produkt1/71vBNHwEJmL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler – Ansicht 3" data-src="/assets/images/products/Produkt1/813lwRtyO0L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler – Ansicht 4" data-src="/assets/images/products/Produkt1/81CsZmj19hL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname XYZ</h1>
-          <div class="price">129,00€</div>
+          <h1 data-product-name>Beurer BR 60 Insektenstichheiler</h1>
+          <div class="price">129,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -387,7 +387,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4mxEW25" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -428,36 +428,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
-              <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
-              </div>
-            </a>
-          </article>
-
-          <article class="rel-card">
             <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+              <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel)" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Sanotact Elektrolyte Plus (20 Beutel)</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
             <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+              <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Bienengift Gelenkcreme</strong>
+                <span class="price">119,00 €</span>
+              </div>
+            </a>
+          </article>
+
+          <article class="rel-card">
+            <a href="produkt-detail4.html">
+              <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray" />
+              <div class="body">
+                <strong>Autan Multi Insect Pumpspray</strong>
+                <span class="price">139,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail10.html
+++ b/frontend/produkt-detail10.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 10 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Behrend Warzenmittel für Hand & Fuß | DropNGo</title>
+  <meta name="description" content="Behrend Warzenmittel für Hand & Fuß – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 10 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Behrend Warzenmittel für Hand & Fuß | DropNGo" />
+<meta property="og:description" content="Behrend Warzenmittel für Hand & Fuß – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail10.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Behrend Warzenmittel für Hand & Fuß</strong>
+      <span class="price">109,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/45V7Z8D" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Behrend Warzenmittel für Hand & Fuß</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p10.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/p10.jpg" alt="Behrend Warzenmittel für Hand & Fuß" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/p10.jpg" alt="Ansicht 1" data-src="/assets/images/products/p10.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 10</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Behrend Warzenmittel für Hand & Fuß</h1>
+          <div class="price">109,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/45V7Z8D" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail11.html">
+              <img src="/assets/images/products/Produkt11/611TpwuiETL._AC_SL1500_.jpg" alt="Fußmassagerolle für Plantarfasziitis" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Fußmassagerolle für Plantarfasziitis</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail12.html">
+              <img src="/assets/images/products/Produkt12/818Xtkh3sfL._AC_SL1500_.jpg" alt="Glückstoff® Orthopädisches Kissen" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Glückstoff® Orthopädisches Kissen</strong>
+                <span class="price">119,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail13.html">
+              <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="health Press" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>health Press</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail11.html
+++ b/frontend/produkt-detail11.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 11 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Fußmassagerolle für Plantarfasziitis | DropNGo</title>
+  <meta name="description" content="Fußmassagerolle für Plantarfasziitis – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 11 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Fußmassagerolle für Plantarfasziitis | DropNGo" />
+<meta property="og:description" content="Fußmassagerolle für Plantarfasziitis – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail11.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Fußmassagerolle für Plantarfasziitis</strong>
+      <span class="price">149,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/47L9HvH" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Fußmassagerolle für Plantarfasziitis</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p11.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/p11.jpg" alt="Fußmassagerolle für Plantarfasziitis" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/p11.jpg" alt="Ansicht 1" data-src="/assets/images/products/p11.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 11</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Fußmassagerolle für Plantarfasziitis</h1>
+          <div class="price">149,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/47L9HvH" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail12.html">
+              <img src="/assets/images/products/Produkt12/818Xtkh3sfL._AC_SL1500_.jpg" alt="Glückstoff® Orthopädisches Kissen" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Glückstoff® Orthopädisches Kissen</strong>
+                <span class="price">119,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail13.html">
+              <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="health Press" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>health Press</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail14.html">
+              <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="heat it - Insektenstichheiler für dein Smartphone" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>heat it - Insektenstichheiler für dein Smartphone</strong>
+                <span class="price">79,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail12.html
+++ b/frontend/produkt-detail12.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 12 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Glückstoff® Orthopädisches Kissen | DropNGo</title>
+  <meta name="description" content="Glückstoff® Orthopädisches Kissen – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 12 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Glückstoff® Orthopädisches Kissen | DropNGo" />
+<meta property="og:description" content="Glückstoff® Orthopädisches Kissen – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail12.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Glückstoff® Orthopädisches Kissen</strong>
+      <span class="price">119,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/3UJYALW" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Glückstoff® Orthopädisches Kissen</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/p12.jpg" alt="Produktbild: Produktname" id="heroImg">
+            <img src="/assets/images/products/p12.jpg" alt="Glückstoff® Orthopädisches Kissen" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/p12.jpg" alt="Ansicht 1" data-src="/assets/images/products/p12.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 12</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Glückstoff® Orthopädisches Kissen</h1>
+          <div class="price">119,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/3UJYALW" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail13.html">
+              <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="health Press" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>health Press</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail14.html">
+              <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="heat it - Insektenstichheiler für dein Smartphone" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>heat it - Insektenstichheiler für dein Smartphone</strong>
+                <span class="price">79,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail15.html">
+              <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Letitwell Heizkissen" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Letitwell Heizkissen</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail13.html
+++ b/frontend/produkt-detail13.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 13 | DropNGo</title>
-  <meta name="description" content="Produkt 13 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>health Press | DropNGo</title>
+  <meta name="description" content="health Press – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 13 | DropNGo" />
-<meta property="og:description" content="Produkt 13 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="health Press | DropNGo" />
+<meta property="og:description" content="health Press – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail13.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 13</strong>
+      <strong id="scName">health Press</strong>
       <span class="price">89,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/3HFB5kg" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 13</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">health Press</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="Produktbild: Produktname 13" id="heroImg">
+            <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="health Press 13" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt13/71JD56mugsL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 13</h1>
-          <div class="price">89,00 €</div>
+          <h1 data-product-name>health Press</h1>
+          <div class="price">89,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 1–3 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/3HFB5kg" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail14.html">
+              <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="heat it - Insektenstichheiler für dein Smartphone" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>heat it - Insektenstichheiler für dein Smartphone</strong>
+                <span class="price">79,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail15.html">
+              <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Letitwell Heizkissen" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
+                <strong>Letitwell Heizkissen</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail16.html">
+              <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="SANOHRA fly" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>SANOHRA fly</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail14.html
+++ b/frontend/produkt-detail14.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 14 | DropNGo</title>
-  <meta name="description" content="Produkt 14 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>heat it - Insektenstichheiler für dein Smartphone | DropNGo</title>
+  <meta name="description" content="heat it - Insektenstichheiler für dein Smartphone – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 14 | DropNGo" />
-<meta property="og:description" content="Produkt 14 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="heat it - Insektenstichheiler für dein Smartphone | DropNGo" />
+<meta property="og:description" content="heat it - Insektenstichheiler für dein Smartphone – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail14.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 14</strong>
+      <strong id="scName">heat it - Insektenstichheiler für dein Smartphone</strong>
       <span class="price">79,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/45y9sCL" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 14</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">heat it - Insektenstichheiler für dein Smartphone</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="Produktbild: Produktname 14" id="heroImg">
+            <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="heat it - Insektenstichheiler für dein Smartphone 14" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt14/71TnNDQ6IjL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 14</h1>
-          <div class="price">79,00 €</div>
+          <h1 data-product-name>heat it - Insektenstichheiler für dein Smartphone</h1>
+          <div class="price">79,00 €</div>
           <p class="meta">Nur noch wenige auf Lager • Versandzeit: 3–5 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/45y9sCL" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail15.html">
+              <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Letitwell Heizkissen" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>Letitwell Heizkissen</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail16.html">
+              <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="SANOHRA fly" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
+                <strong>SANOHRA fly</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail17.html">
+              <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="SOS Hämorrhoiden-Salbe" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>SOS Hämorrhoiden-Salbe</strong>
+                <span class="price">59,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail15.html
+++ b/frontend/produkt-detail15.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 15 | DropNGo</title>
-  <meta name="description" content="Produkt 15 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Letitwell Heizkissen | DropNGo</title>
+  <meta name="description" content="Letitwell Heizkissen – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 15 | DropNGo" />
-<meta property="og:description" content="Produkt 15 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="Letitwell Heizkissen | DropNGo" />
+<meta property="og:description" content="Letitwell Heizkissen – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail15.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 15</strong>
+      <strong id="scName">Letitwell Heizkissen</strong>
       <span class="price">99,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4myKqtm" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 15</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Letitwell Heizkissen</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Produktbild: Produktname 15" id="heroImg">
+            <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Letitwell Heizkissen 15" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt15/61v1DDxzytL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 15</h1>
-          <div class="price">99,00 €</div>
+          <h1 data-product-name>Letitwell Heizkissen</h1>
+          <div class="price">99,00 €</div>
           <p class="meta">Vorbestellbar • Versandzeit: 5–7 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4myKqtm" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail16.html">
+              <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="SANOHRA fly" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>SANOHRA fly</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail17.html">
+              <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="SOS Hämorrhoiden-Salbe" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
+                <strong>SOS Hämorrhoiden-Salbe</strong>
+                <span class="price">59,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail18.html">
+              <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="SOS Mund-Heil-Gel" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>SOS Mund-Heil-Gel</strong>
+                <span class="price">139,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail16.html
+++ b/frontend/produkt-detail16.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 16 | DropNGo</title>
-  <meta name="description" content="Produkt 16 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>SANOHRA fly | DropNGo</title>
+  <meta name="description" content="SANOHRA fly – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 16 | DropNGo" />
-<meta property="og:description" content="Produkt 16 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="SANOHRA fly | DropNGo" />
+<meta property="og:description" content="SANOHRA fly – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail16.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 16</strong>
+      <strong id="scName">SANOHRA fly</strong>
       <span class="price">109,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/45PqMSu" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 16</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">SANOHRA fly</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="Produktbild: Produktname 16" id="heroImg">
+            <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="SANOHRA fly 16" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt16/71NdT-K23SL._AC_SL1500_.jpg">
@@ -335,8 +335,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 16</h1>
-          <div class="price">109,00 €</div>
+          <h1 data-product-name>SANOHRA fly</h1>
+          <div class="price">109,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -354,7 +354,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/45PqMSu" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -395,36 +395,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail17.html">
+              <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="SOS Hämorrhoiden-Salbe" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>SOS Hämorrhoiden-Salbe</strong>
+                <span class="price">59,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail18.html">
+              <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="SOS Mund-Heil-Gel" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
+                <strong>SOS Mund-Heil-Gel</strong>
+                <span class="price">139,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail19.html">
+              <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="TerraTherm Wärmepflaster Rücken" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>TerraTherm Wärmepflaster Rücken</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail17.html
+++ b/frontend/produkt-detail17.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 17 | DropNGo</title>
-  <meta name="description" content="Produkt 17 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>SOS Hämorrhoiden-Salbe | DropNGo</title>
+  <meta name="description" content="SOS Hämorrhoiden-Salbe – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 17 | DropNGo" />
-<meta property="og:description" content="Produkt 17 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="SOS Hämorrhoiden-Salbe | DropNGo" />
+<meta property="og:description" content="SOS Hämorrhoiden-Salbe – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail17.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 17</strong>
+      <strong id="scName">SOS Hämorrhoiden-Salbe</strong>
       <span class="price">59,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/41ijbuv" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 17</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">SOS Hämorrhoiden-Salbe</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="Produktbild: Produktname 17" id="heroImg">
+            <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="SOS Hämorrhoiden-Salbe 17" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt17/71-tHY3NtAL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 17</h1>
-          <div class="price">59,00 €</div>
+          <h1 data-product-name>SOS Hämorrhoiden-Salbe</h1>
+          <div class="price">59,00 €</div>
           <p class="meta">Versandfertig in 24h</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/41ijbuv" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
+            <a href="produkt-detail18.html">
+              <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="SOS Mund-Heil-Gel" />
+              <div class="body">
+                <strong>SOS Mund-Heil-Gel</strong>
+                <span class="price">139,00 €</span>
+              </div>
+            </a>
+          </article>
+
+          <article class="rel-card">
+            <a href="produkt-detail19.html">
+              <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="TerraTherm Wärmepflaster Rücken" />
+              <div class="body">
+                <strong>TerraTherm Wärmepflaster Rücken</strong>
+                <span class="price">149,00 €</span>
+              </div>
+            </a>
+          </article>
+
+          <article class="rel-card">
             <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+              <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
-              </div>
-            </a>
-          </article>
-
-          <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
-              <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
-              </div>
-            </a>
-          </article>
-
-          <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
-              <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>Beurer BR 60 Insektenstichheiler</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail18.html
+++ b/frontend/produkt-detail18.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 18 | DropNGo</title>
-  <meta name="description" content="Produkt 18 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>SOS Mund-Heil-Gel | DropNGo</title>
+  <meta name="description" content="SOS Mund-Heil-Gel – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 18 | DropNGo" />
-<meta property="og:description" content="Produkt 18 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="SOS Mund-Heil-Gel | DropNGo" />
+<meta property="og:description" content="SOS Mund-Heil-Gel – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail18.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 18</strong>
+      <strong id="scName">SOS Mund-Heil-Gel</strong>
       <span class="price">139,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/3JxjH1O" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 18</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">SOS Mund-Heil-Gel</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="Produktbild: Produktname 18" id="heroImg">
+            <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="SOS Mund-Heil-Gel 18" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt18/614VDelgDZL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 18</h1>
-          <div class="price">139,00 €</div>
+          <h1 data-product-name>SOS Mund-Heil-Gel</h1>
+          <div class="price">139,00 €</div>
           <p class="meta">Lieferung in 3–5 Werktagen</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/3JxjH1O" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -397,36 +397,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail19.html">
+              <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="TerraTherm Wärmepflaster Rücken" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>TerraTherm Wärmepflaster Rücken</strong>
+                <span class="price">149,00 €</span>
+              </div>
+            </a>
+          </article>
+
+          <article class="rel-card">
+            <a href="produkt-detail1.html">
+              <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler" />
+              <div class="body">
+                <strong>Beurer BR 60 Insektenstichheiler</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
             <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+              <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel)" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
-              </div>
-            </a>
-          </article>
-
-          <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
-              <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>Sanotact Elektrolyte Plus (20 Beutel)</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail19.html
+++ b/frontend/produkt-detail19.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 19 | DropNGo</title>
-  <meta name="description" content="Produkt 19 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>TerraTherm Wärmepflaster Rücken | DropNGo</title>
+  <meta name="description" content="TerraTherm Wärmepflaster Rücken – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 19 | DropNGo" />
-<meta property="og:description" content="Produkt 19 – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <meta property="og:title" content="TerraTherm Wärmepflaster Rücken | DropNGo" />
+<meta property="og:description" content="TerraTherm Wärmepflaster Rücken – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail19.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname 19</strong>
+      <strong id="scName">TerraTherm Wärmepflaster Rücken</strong>
       <span class="price">149,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4oRhHl1" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,14 +317,14 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname 19</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">TerraTherm Wärmepflaster Rücken</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="Produktbild: Produktname 19" id="heroImg">
+            <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="TerraTherm Wärmepflaster Rücken 19" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
             <img src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg" alt="Ansicht 1" data-src="/assets/images/products/Produkt19/7164E0QpeCL._AC_SL1500_.jpg">
@@ -337,8 +337,8 @@
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 19</h1>
-          <div class="price">149,00 €</div>
+          <h1 data-product-name>TerraTherm Wärmepflaster Rücken</h1>
+          <div class="price">149,00 €</div>
           <p class="meta">Kostenloser Versand • Lieferzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -356,7 +356,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4oRhHl1" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -398,35 +398,38 @@
         <div class="rel-grid">
           <article class="rel-card">
             <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+              <img src="/assets/images/products/Produkt1/61frjp3cEpL._AC_SL1500_.jpg" alt="Beurer BR 60 Insektenstichheiler" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00&nbsp;€</span>
+                <strong>Beurer BR 60 Insektenstichheiler</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
             <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+              <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel)" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00&nbsp;€</span>
+                <strong>Sanotact Elektrolyte Plus (20 Beutel)</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
             <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+              <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00&nbsp;€</span>
+                <strong>Bienengift Gelenkcreme</strong>
+                <span class="price">119,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail2.html
+++ b/frontend/produkt-detail2.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 2 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Sanotact Elektrolyte Plus (20 Beutel) | DropNGo</title>
+  <meta name="description" content="Sanotact Elektrolyte Plus (20 Beutel) – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 2 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Sanotact Elektrolyte Plus (20 Beutel) | DropNGo" />
+<meta property="og:description" content="Sanotact Elektrolyte Plus (20 Beutel) – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail2.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -306,10 +306,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Sanotact Elektrolyte Plus (20 Beutel)</strong>
+      <span class="price">149,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4mWUNH9" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,27 +317,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Sanotact Elektrolyte Plus (20 Beutel)</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Produktbild: Produkt 2" id="heroImg">
+            <img src="/assets/images/products/Produkt2/71Pge83U50L._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel)" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 1" data-src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 2" data-src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 3" data-src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg" alt="Produkt 2 – Ansicht 4" data-src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel) – Ansicht 1" data-src="/assets/images/products/Produkt2/71QmTqY20UL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel) – Ansicht 2" data-src="/assets/images/products/Produkt2/71j6m+1FXIL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel) – Ansicht 3" data-src="/assets/images/products/Produkt2/71sxOEJh1iL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg" alt="Sanotact Elektrolyte Plus (20 Beutel) – Ansicht 4" data-src="/assets/images/products/Produkt2/81Lt5jvhNGL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname XYZ</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Sanotact Elektrolyte Plus (20 Beutel)</h1>
+          <div class="price">149,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 <div style="
   background: rgba(24,161,150,0.08);
@@ -354,7 +354,7 @@
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
             <!-- Affiliate-Link hier eintragen -->
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4mWUNH9" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -395,36 +395,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p1.jpg" alt="Produkt A" />
-              <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
-              </div>
-            </a>
-          </article>
-
-          <article class="rel-card">
             <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+              <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Bienengift Gelenkcreme</strong>
+                <span class="price">119,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p2b.jpg" alt="Produkt C" />
+            <a href="produkt-detail4.html">
+              <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Autan Multi Insect Pumpspray</strong>
+                <span class="price">139,00 €</span>
+              </div>
+            </a>
+          </article>
+
+          <article class="rel-card">
+            <a href="produkt-detail5.html">
+              <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS" />
+              <div class="body">
+                <strong>Beurer EM 49 Digital TENSEMS</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail3.html
+++ b/frontend/produkt-detail3.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 3 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Bienengift Gelenkcreme | DropNGo</title>
+  <meta name="description" content="Bienengift Gelenkcreme – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 3 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Bienengift Gelenkcreme | DropNGo" />
+<meta property="og:description" content="Bienengift Gelenkcreme – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail3.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Bienengift Gelenkcreme</strong>
+      <span class="price">119,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/45Ma4Ue" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -316,25 +316,25 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Bienengift Gelenkcreme</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Produktbild: Produkt 3" id="heroImg">
+            <img src="/assets/images/products/Produkt3/71+OE7bpPNL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg" alt="Produkt 3 – Ansicht 1" data-src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg" alt="Produkt 3 – Ansicht 2" data-src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme – Ansicht 1" data-src="/assets/images/products/Produkt3/71c9BRkgWnL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg" alt="Bienengift Gelenkcreme – Ansicht 2" data-src="/assets/images/products/Produkt3/71zRxxh-9yL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname XYZ</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Bienengift Gelenkcreme</h1>
+          <div class="price">119,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 <div style="
   background: rgba(24,161,150,0.08);
@@ -351,7 +351,7 @@
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
             <!-- Affiliate-Link hier eintragen -->
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/45Ma4Ue" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -392,36 +392,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p1.jpg" alt="Produkt A" />
+            <a href="produkt-detail4.html">
+              <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Autan Multi Insect Pumpspray</strong>
+                <span class="price">139,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt B" />
+            <a href="produkt-detail5.html">
+              <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Beurer EM 49 Digital TENSEMS</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p3b.jpg" alt="Produkt C" />
+            <a href="produkt-detail6.html">
+              <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Abtei Venen Aktiv Balsam" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Abtei Venen Aktiv Balsam</strong>
+                <span class="price">159,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail4.html
+++ b/frontend/produkt-detail4.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 4 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Autan Multi Insect Pumpspray | DropNGo</title>
+  <meta name="description" content="Autan Multi Insect Pumpspray – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 4 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Autan Multi Insect Pumpspray | DropNGo" />
+<meta property="og:description" content="Autan Multi Insect Pumpspray – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail4.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Autan Multi Insect Pumpspray</strong>
+      <span class="price">139,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/45U19QM" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,27 +317,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Autan Multi Insect Pumpspray</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Produktbild: Produkt 4" id="heroImg">
+            <img src="/assets/images/products/Produkt4/61a05r0LxML._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 1" data-src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 2" data-src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 3" data-src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg" alt="Produkt 4 – Ansicht 4" data-src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray – Ansicht 1" data-src="/assets/images/products/Produkt4/61bwU+dKPbL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray – Ansicht 2" data-src="/assets/images/products/Produkt4/71pifdkzI6L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray – Ansicht 3" data-src="/assets/images/products/Produkt4/81+eFta18vL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg" alt="Autan Multi Insect Pumpspray – Ansicht 4" data-src="/assets/images/products/Produkt4/81AKsZln6tL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 04</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Autan Multi Insect Pumpspray</h1>
+          <div class="price">139,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -355,7 +355,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/45U19QM" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -396,36 +396,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail5.html">
+              <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Beurer EM 49 Digital TENSEMS</strong>
+                <span class="price">89,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail6.html">
+              <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Abtei Venen Aktiv Balsam" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Abtei Venen Aktiv Balsam</strong>
+                <span class="price">159,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail7.html">
+              <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Ashwagandha Kapseln hochdosiert 120x - 600 mg</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail5.html
+++ b/frontend/produkt-detail5.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 5 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Beurer EM 49 Digital TENSEMS | DropNGo</title>
+  <meta name="description" content="Beurer EM 49 Digital TENSEMS – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 5 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Beurer EM 49 Digital TENSEMS | DropNGo" />
+<meta property="og:description" content="Beurer EM 49 Digital TENSEMS – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail5.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Beurer EM 49 Digital TENSEMS</strong>
+      <span class="price">89,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4oHXbDg" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,27 +317,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Beurer EM 49 Digital TENSEMS</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Produktbild: Produkt 5" id="heroImg">
+            <img src="/assets/images/products/Produkt5/71G406JeakL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 1" data-src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 2" data-src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 3" data-src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg" alt="Produkt 5 – Ansicht 4" data-src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS – Ansicht 1" data-src="/assets/images/products/Produkt5/71pO0HG9zCL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS – Ansicht 2" data-src="/assets/images/products/Produkt5/810adtCeqlL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS – Ansicht 3" data-src="/assets/images/products/Produkt5/81AkXv+XTXL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg" alt="Beurer EM 49 Digital TENSEMS – Ansicht 4" data-src="/assets/images/products/Produkt5/81DQWVs+7SL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 05</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Beurer EM 49 Digital TENSEMS</h1>
+          <div class="price">89,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -355,7 +355,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4oHXbDg" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -396,36 +396,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail6.html">
+              <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Abtei Venen Aktiv Balsam" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Abtei Venen Aktiv Balsam</strong>
+                <span class="price">159,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail7.html">
+              <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Ashwagandha Kapseln hochdosiert 120x - 600 mg</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail8.html">
+              <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>AUDISPRAY Ultra</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail6.html
+++ b/frontend/produkt-detail6.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 6 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Abtei Venen Aktiv Balsam | DropNGo</title>
+  <meta name="description" content="Abtei Venen Aktiv Balsam – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 6 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Abtei Venen Aktiv Balsam | DropNGo" />
+<meta property="og:description" content="Abtei Venen Aktiv Balsam – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail6.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Abtei Venen Aktiv Balsam</strong>
+      <span class="price">159,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/3UJIYbe" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,26 +317,26 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Abtei Venen Aktiv Balsam</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Produktbild: Produkt 6" id="heroImg">
+            <img src="/assets/images/products/Produkt6/51PZIKfMqsS._AC_.jpg" alt="Abtei Venen Aktiv Balsam" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg" alt="Produkt 6 – Ansicht 1" data-src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg" alt="Produkt 6 – Ansicht 2" data-src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt6/videoframe_31470.png" alt="Produkt 6 – Ansicht 3" data-src="/assets/images/products/Produkt6/videoframe_31470.png">
+            <img src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg" alt="Abtei Venen Aktiv Balsam – Ansicht 1" data-src="/assets/images/products/Produkt6/71SrDmj7m6L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg" alt="Abtei Venen Aktiv Balsam – Ansicht 2" data-src="/assets/images/products/Produkt6/71xcpu1drkL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt6/videoframe_31470.png" alt="Abtei Venen Aktiv Balsam – Ansicht 3" data-src="/assets/images/products/Produkt6/videoframe_31470.png">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 06</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Abtei Venen Aktiv Balsam</h1>
+          <div class="price">159,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -354,7 +354,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/3UJIYbe" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -395,36 +395,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail7.html">
+              <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Ashwagandha Kapseln hochdosiert 120x - 600 mg</strong>
+                <span class="price">129,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail8.html">
+              <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>AUDISPRAY Ultra</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail9.html">
+              <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Bauerfeind ViscoSpot Fersenkisse</strong>
+                <span class="price">179,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail7.html
+++ b/frontend/produkt-detail7.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 7 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Ashwagandha Kapseln hochdosiert 120x - 600 mg | DropNGo</title>
+  <meta name="description" content="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 7 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Ashwagandha Kapseln hochdosiert 120x - 600 mg | DropNGo" />
+<meta property="og:description" content="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail7.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
+      <strong id="scName">Ashwagandha Kapseln hochdosiert 120x - 600 mg</strong>
       <span class="price">129,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/3JQm0wI" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,27 +317,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Ashwagandha Kapseln hochdosiert 120x - 600 mg</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Produktbild: Produkt 7" id="heroImg">
+            <img src="/assets/images/products/Produkt7/714g-nkXivL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 1" data-src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 2" data-src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 3" data-src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg" alt="Produkt 7 – Ansicht 4" data-src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Ansicht 1" data-src="/assets/images/products/Produkt7/812pFn6gCsL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Ansicht 2" data-src="/assets/images/products/Produkt7/817+lDLGVDL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Ansicht 3" data-src="/assets/images/products/Produkt7/81AYHNLQX+L._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg" alt="Ashwagandha Kapseln hochdosiert 120x - 600 mg – Ansicht 4" data-src="/assets/images/products/Produkt7/81UZao7QDIL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 07</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Ashwagandha Kapseln hochdosiert 120x - 600 mg</h1>
+          <div class="price">129,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -355,7 +355,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/3JQm0wI" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -396,36 +396,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail8.html">
+              <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>AUDISPRAY Ultra</strong>
+                <span class="price">99,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail9.html">
+              <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Bauerfeind ViscoSpot Fersenkisse</strong>
+                <span class="price">179,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail10.html">
+              <img src="/assets/images/products/Produkt10/videoframe_22737.png" alt="Behrend Warzenmittel für Hand & Fuß" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Behrend Warzenmittel für Hand & Fuß</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail8.html
+++ b/frontend/produkt-detail8.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 8 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>AUDISPRAY Ultra | DropNGo</title>
+  <meta name="description" content="AUDISPRAY Ultra – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 8 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="AUDISPRAY Ultra | DropNGo" />
+<meta property="og:description" content="AUDISPRAY Ultra – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail8.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">AUDISPRAY Ultra</strong>
+      <span class="price">99,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4fPijDv" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,27 +317,27 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">AUDISPRAY Ultra</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="Produktbild: Produkt 8" id="heroImg">
+            <img src="/assets/images/products/Produkt8/61dw+4JnGBL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 1" data-src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 2" data-src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 3" data-src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg">
-            <img src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg" alt="Produkt 8 – Ansicht 4" data-src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra – Ansicht 1" data-src="/assets/images/products/Produkt8/711Dct9-wNL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra – Ansicht 2" data-src="/assets/images/products/Produkt8/719fgcIWMcL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra – Ansicht 3" data-src="/assets/images/products/Produkt8/71PZWwQ3uZL._AC_SL1500_.jpg">
+            <img src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg" alt="AUDISPRAY Ultra – Ansicht 4" data-src="/assets/images/products/Produkt8/71mrmos9wWL._AC_SL1500_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 08</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>AUDISPRAY Ultra</h1>
+          <div class="price">99,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -355,7 +355,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4fPijDv" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -396,36 +396,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail9.html">
+              <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Bauerfeind ViscoSpot Fersenkisse</strong>
+                <span class="price">179,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail10.html">
+              <img src="/assets/images/products/Produkt10/videoframe_22737.png" alt="Behrend Warzenmittel für Hand & Fuß" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Behrend Warzenmittel für Hand & Fuß</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail11.html">
+              <img src="/assets/images/products/Produkt11/611TpwuiETL._AC_SL1500_.jpg" alt="Fußmassagerolle für Plantarfasziitis" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Fußmassagerolle für Plantarfasziitis</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/frontend/produkt-detail9.html
+++ b/frontend/produkt-detail9.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Produktdetail 9 | DropNGo</title>
-  <meta name="description" content="Produktdetails, Preis, Merkmale und Affiliate‑Kaufoptionen." />
+  <title>Bauerfeind ViscoSpot Fersenkisse | DropNGo</title>
+  <meta name="description" content="Bauerfeind ViscoSpot Fersenkisse – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
   <link rel="icon" href="assets/favicon.ico" />
 
-  <meta property="og:title" content="Produktdetail 9 | DropNGo" />
-<meta property="og:description" content="Produktdetails, Preis, Merkmale und Affiliate-Kaufoptionen." />
+  <meta property="og:title" content="Bauerfeind ViscoSpot Fersenkisse | DropNGo" />
+<meta property="og:description" content="Bauerfeind ViscoSpot Fersenkisse – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://www.dropngo.shop/produkt-detail9.html" />
 <meta property="og:image" content="https://www.dropngo.shop/assets/images/dropngo-preview.png" />
@@ -305,10 +305,10 @@
 <div class="sticky-cta" role="region" aria-label="Kaufaktion">
   <div class="container sticky-cta__inner">
     <div class="sc-title">
-      <strong id="scName">Produktname</strong>
-      <span class="price">129,00 €</span>
+      <strong id="scName">Bauerfeind ViscoSpot Fersenkisse</strong>
+      <span class="price">179,00 €</span>
     </div>
-    <a class="btn btn--primary" href="#kaufen">Beim Partner kaufen</a>
+    <a class="btn btn--primary" href="https://amzn.to/4mXPuY0" target="_blank" rel="nofollow noopener">Beim Partner kaufen</a>
   </div>
 </div>
 
@@ -317,24 +317,24 @@
   <main>
     <div class="container">
       <nav class="breadcrumbs" aria-label="Brotkrumen">
-        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Produktname</span>
+        <a href="index.html">Home</a> &nbsp;/&nbsp; <a href="products.html">Produkte</a> &nbsp;/&nbsp; <span aria-current="page">Bauerfeind ViscoSpot Fersenkisse</span>
       </nav>
 
       <section class="product-wrap" id="produkt">
         <!-- Galerie / Medien -->
         <aside class="gallery">
           <div class="hero-media" id="heroMedia">
-            <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Produktbild: Produkt 9" id="heroImg">
+            <img src="/assets/images/products/Produkt9/31mP0jcLzzL._AC_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse" id="heroImg">
           </div>
           <div class="thumbs" aria-label="Weitere Ansichten">
-            <img src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg" alt="Produkt 9 – Ansicht 1" data-src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg">
+            <img src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg" alt="Bauerfeind ViscoSpot Fersenkisse – Ansicht 1" data-src="/assets/images/products/Produkt9/612XAfp9Q8L._AC_SL1000_.jpg">
           </div>
         </aside>
 
         <!-- Info -->
         <article class="info">
-          <h1 data-product-name>Produktname 09</h1>
-          <div class="price">129,00 €</div>
+          <h1 data-product-name>Bauerfeind ViscoSpot Fersenkisse</h1>
+          <div class="price">179,00 €</div>
           <p class="meta">Sofort verfügbar • Versandzeit: 2–4 Werktage</p>
 
           <div class="cta-row" role="group" aria-label="Kaufoptionen">
@@ -352,7 +352,7 @@
 </div>
 
 
-            <a class="cta-primary" href="https://dein-affiliate-link.example" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
+            <a class="cta-primary" href="https://amzn.to/4mXPuY0" target="_blank" rel="nofollow noopener">Bei Partner kaufen</a>
             <a class="cta-ghost" href="#details">Details ansehen</a>
           </div>
 
@@ -393,36 +393,39 @@
         <h2 id="related-head">Ähnliche Produkte</h2>
         <div class="rel-grid">
           <article class="rel-card">
-            <a href="produkt-detail1.html">
-              <img src="/assets/images/products/p2.jpg" alt="Produkt A" />
+            <a href="produkt-detail10.html">
+              <img src="/assets/images/products/Produkt10/videoframe_22737.png" alt="Behrend Warzenmittel für Hand & Fuß" />
               <div class="body">
-                <strong>Produkt A</strong>
-                <span class="price">119,00 €</span>
+                <strong>Behrend Warzenmittel für Hand & Fuß</strong>
+                <span class="price">109,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail2.html">
-              <img src="/assets/images/products/p3.jpg" alt="Produkt B" />
+            <a href="produkt-detail11.html">
+              <img src="/assets/images/products/Produkt11/611TpwuiETL._AC_SL1500_.jpg" alt="Fußmassagerolle für Plantarfasziitis" />
               <div class="body">
-                <strong>Produkt B</strong>
-                <span class="price">139,00 €</span>
+                <strong>Fußmassagerolle für Plantarfasziitis</strong>
+                <span class="price">149,00 €</span>
               </div>
             </a>
           </article>
 
           <article class="rel-card">
-            <a href="produkt-detail3.html">
-              <img src="/assets/images/products/p4.jpg" alt="Produkt C" />
+            <a href="produkt-detail12.html">
+              <img src="/assets/images/products/Produkt12/818Xtkh3sfL._AC_SL1500_.jpg" alt="Glückstoff® Orthopädisches Kissen" />
               <div class="body">
-                <strong>Produkt C</strong>
-                <span class="price">149,00 €</span>
+                <strong>Glückstoff® Orthopädisches Kissen</strong>
+                <span class="price">119,00 €</span>
               </div>
             </a>
           </article>
         </div>
       </section>
+
+
+
     </div>
   </main>
 

--- a/scripts/updateProductDetails.js
+++ b/scripts/updateProductDetails.js
@@ -1,0 +1,114 @@
+const fs = require('fs');
+const path = require('path');
+
+// Parse products.html to get product data (name, price, image)
+const productsHtml = fs.readFileSync(path.join(__dirname, '..', 'frontend', 'products.html'), 'utf8');
+const productRegex = /<a href="produkt-detail(\d+)\.html"[\s\S]*?<img src="([^"]+)" alt="([^"]+)"[\s\S]*?<span class="price">([^<]+)<\/span>/g;
+let match;
+const products = {};
+while ((match = productRegex.exec(productsHtml)) !== null) {
+  const id = parseInt(match[1], 10);
+  let image = match[2].trim();
+  let name = match[3].trim();
+  let price = match[4].trim();
+  // Ensure price has space before €
+  price = price.replace(/\s*€/, ' €');
+  products[id] = { id, name, price, image };
+}
+
+// Helper to sanitize affiliate links by removing price-related query params
+function sanitizeLink(url) {
+  try {
+    const u = new URL(url);
+    ['price', 'amount', 'preis'].forEach(param => u.searchParams.delete(param));
+    return u.toString();
+  } catch (e) {
+    return url;
+  }
+}
+
+// Read affiliate links (and optional price from text file if present)
+const namesDir = path.join(__dirname, '..', 'frontend', 'ProduktNamen');
+for (const dir of fs.readdirSync(namesDir)) {
+  const m = dir.match(/^(\d+)\s/);
+  if (!m) continue;
+  const id = parseInt(m[1], 10);
+  const p = products[id];
+  if (!p) continue;
+  const txtPath = path.join(namesDir, dir, 'Beschreibung und Link.txt');
+  const lines = fs.readFileSync(txtPath, 'utf8').split(/\r?\n/);
+  const link = sanitizeLink(lines[0].trim());
+  p.link = link;
+  if (lines[1] && lines[1].trim()) {
+    const price = lines[1].trim().replace(/\s*€/, ' €');
+    p.price = price; // override if provided
+  }
+}
+
+const ids = Object.keys(products).map(Number).sort((a,b)=>a-b);
+
+// Generate related products for each id using next three ids
+function relatedFor(id) {
+  const idx = ids.indexOf(id);
+  const rel = [ids[(idx+1)%ids.length], ids[(idx+2)%ids.length], ids[(idx+3)%ids.length]];
+  return rel.map(rid => products[rid]);
+}
+
+function generateRelatedHTML(id) {
+  const rel = relatedFor(id);
+  const items = rel.map(p => `          <article class="rel-card">
+            <a href="produkt-detail${p.id}.html">
+              <img src="${p.image}" alt="${p.name}" />
+              <div class="body">
+                <strong>${p.name}</strong>
+                <span class="price">${p.price}</span>
+              </div>
+            </a>
+          </article>`).join('\n\n');
+  return `      <section class="related" aria-labelledby="related-head">
+        <h2 id="related-head">Ähnliche Produkte</h2>
+        <div class="rel-grid">
+${items}
+        </div>
+      </section>`;
+}
+
+// Update each product detail page
+for (const id of ids) {
+  const p = products[id];
+  const filePath = path.join(__dirname, '..', 'frontend', `produkt-detail${id}.html`);
+  let html = fs.readFileSync(filePath, 'utf8');
+
+  // Product name placeholders
+  html = html.replace(/<strong id="scName">[^<]*<\/strong>/, `<strong id="scName">${p.name}</strong>`);
+  html = html.replace(/(<a href="index.html">Home<\/a> &nbsp;\/&nbsp; <a href="products.html">Produkte<\/a> &nbsp;\/&nbsp; <span aria-current="page">)[^<]*(<\/span>)/, `$1${p.name}$2`);
+  html = html.replace(/<h1 data-product-name>[^<]*<\/h1>/, `<h1 data-product-name>${p.name}</h1>`);
+  html = html.replace(/<meta name="description" content="[^"]*" \/>/, `<meta name="description" content="${p.name} – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />`);
+  html = html.replace(/<meta property="og:description" content="[^"]*" \/>/, `<meta property="og:description" content="${p.name} – Details, Preis, Merkmale und Affiliate‑Kaufoptionen." />`);
+  html = html.replace(/<title>[^<]*<\/title>/, `<title>${p.name} | DropNGo<\/title>`);
+  html = html.replace(/<meta property="og:title" content="[^"]*" \/>/, `<meta property="og:title" content="${p.name} | DropNGo" \/>`);
+  // Alt texts for hero image and thumbs
+  html = html.replace(/alt="Produkt[^"]*?"/g, (m) => {
+    // Preserve suffix like " – Ansicht 1" if exists
+    const suffixMatch = m.match(/Produkt(?:name|\s*\d+)([^\"]*)"/);
+    const suffix = suffixMatch ? suffixMatch[1] : '';
+    return `alt="${p.name}${suffix}"`;
+  });
+  html = html.replace(/alt="Produktbild: [^"]*"/, `alt="Produktbild: ${p.name}"`);
+
+  // Affiliate link in main CTA
+  html = html.replace(/<a class="cta-primary" href="[^"]*"[^>]*>[^<]*<\/a>/, `<a class="cta-primary" href="${p.link}" target="_blank" rel="nofollow noopener">Bei Partner kaufen<\/a>`);
+
+  // Affiliate link in sticky CTA
+  html = html.replace(/<a class="btn btn--primary"[^>]*>Beim Partner kaufen<\/a>/, `<a class="btn btn--primary" href="${p.link}" target="_blank" rel="nofollow noopener">Beim Partner kaufen<\/a>`);
+
+  // Prices
+  html = html.replace(/(<div class="price">)[^<]*(<\/div>)/, `$1${p.price}$2`);
+  html = html.replace(/(<div class="sc-title">\s*<strong id="scName">[^<]*<\/strong>\s*<span class="price">)[^<]*(<\/span>)/, `$1${p.price}$2`);
+
+  // Replace related section
+  html = html.replace(/\n\s*<section class="related"[\s\S]*?<\/section>/, `\n${generateRelatedHTML(id)}\n`);
+
+  fs.writeFileSync(filePath, html, 'utf8');
+  console.log(`Updated produkt-detail${id}.html`);
+}


### PR DESCRIPTION
## Summary
- replace placeholders in product detail pages with real names, prices and affiliate links
- add sticky CTA links with target and rel attributes
- inject related product sections using actual items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae69e9b564832199b38a3460f7b153