### PR TITLE
Add theme toggles to product pages

### DIFF
--- a/frontend/02-sanotact-elektrolyte-plus-20-beutel.html
+++ b/frontend/02-sanotact-elektrolyte-plus-20-beutel.html
@@ -266,6 +266,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -276,12 +277,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
   <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -539,6 +565,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/03-bienengift-gelenkcreme.html
+++ b/frontend/03-bienengift-gelenkcreme.html
@@ -266,6 +266,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -276,12 +277,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
   <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -536,6 +562,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/04-autan-multi-insect-pumpspray.html
+++ b/frontend/04-autan-multi-insect-pumpspray.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
   <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -511,6 +537,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/05-beurer-em-49-digital-tensems.html
+++ b/frontend/05-beurer-em-49-digital-tensems.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -511,6 +537,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/06-abtei-venen-aktiv-balsam.html
+++ b/frontend/06-abtei-venen-aktiv-balsam.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
   <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -510,6 +536,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/07-ashwagandha-kapseln-hochdosiert-120x-600-mg.html
+++ b/frontend/07-ashwagandha-kapseln-hochdosiert-120x-600-mg.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
    <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -511,6 +537,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/08-audispray-ultra-ohrenschmalz-schnelle-aufloesung.html
+++ b/frontend/08-audispray-ultra-ohrenschmalz-schnelle-aufloesung.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
    <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -511,6 +537,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/09-bauerfeind-viscospot-fersenkisse.html
+++ b/frontend/09-bauerfeind-viscospot-fersenkisse.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
   <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -509,6 +535,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/10-behrend-warzenmittel-fuer-hand-und-fuss.html
+++ b/frontend/10-behrend-warzenmittel-fuer-hand-und-fuss.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
    <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -514,6 +540,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/11-fussmassagerolle-fuer-plantarfasziitis.html
+++ b/frontend/11-fussmassagerolle-fuer-plantarfasziitis.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -514,6 +540,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/12-glueckstoff-orthopaedisches-kissen.html
+++ b/frontend/12-glueckstoff-orthopaedisches-kissen.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
     <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -513,6 +539,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 </html>

--- a/frontend/13-health-press-gittertape-fuer-den-ganzen-koerper.html
+++ b/frontend/13-health-press-gittertape-fuer-den-ganzen-koerper.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
    <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/14-heat-it-insektenstichheiler-fuer-dein-smartphone.html
+++ b/frontend/14-heat-it-insektenstichheiler-fuer-dein-smartphone.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/15-letitwell-heizkissen.html
+++ b/frontend/15-letitwell-heizkissen.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/16-sanohra-fly-druckausgleich-fuer-die-ohren.html
+++ b/frontend/16-sanohra-fly-druckausgleich-fuer-die-ohren.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -513,6 +539,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/17-sos-haemorrhoiden-salbe.html
+++ b/frontend/17-sos-haemorrhoiden-salbe.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/18-sos-mund-heil-gel.html
+++ b/frontend/18-sos-mund-heil-gel.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 

--- a/frontend/19-terratherm-waermepflaster-ruecken.html
+++ b/frontend/19-terratherm-waermepflaster-ruecken.html
@@ -265,6 +265,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -275,12 +276,37 @@
       <span class="dng-brand-text">DropNGo</span>
     </a>
 
+<!-- Mobile Theme Toggle (hidden on desktop) -->
+<button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+  </svg>
+</button>
+
 <!-- Desktop-Links -->
 <nav class="dng-links" aria-label="Hauptnavigation">
   <a href="index.html">Home</a>
   <a href="products.html">Produkte</a>
   <a href="blog/bloguebersicht.html">Blog</a>
   <a href="info.html">Über uns</a>
+
+<!-- Desktop Theme Toggle (hidden on mobile) -->
+<button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+  <!-- Sonne (outline) -->
+  <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+    <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </svg>
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
+</button>
+
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
@@ -515,6 +541,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
+  <script src="js/theme.js" defer></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- load theme.css for product pages
- add light/dark toggle buttons to header
- persist theme preference via theme.js

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node test-theme.js` *(custom script verifying toggle and persistence)*

------
https://chatgpt.com/codex/tasks/task_e_68b3344f71dc8321a5438d0ebdc143a6