### PR TITLE
Add shared theme toggle for blog pages

### DIFF
--- a/frontend/blog/beurer-br60-insektenstichheiler.html
+++ b/frontend/blog/beurer-br60-insektenstichheiler.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Beurer BR 60 Insektenstichheiler – Juckreiz schnell lindern</title>
@@ -8,7 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
-    :root{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="dark"]{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="light"]{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 8px 24px rgba(15,23,42,.06)}
+    #themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto}
+    @media (min-width:821px){#themeToggleMobile{display:none!important}#themeToggleDesktop{display:inline-grid!important;margin-left:8px}}
+    @media (max-width:820px){#themeToggleDesktop{display:none!important}#themeToggleMobile{display:inline-grid!important;margin-left:6px!important;margin-top:0!important}}
+    .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15)}
+    .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff}
+    .theme-toggle-btn .icon{display:none}
+    html[data-theme="light"] .theme-toggle-btn .sun{display:block}
+    html[data-theme="dark"] .theme-toggle-btn .moon{display:block}
     *{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
     img{max-width:100%;display:block;border-radius:12px}a{text-decoration:none;color:inherit}.container{width:min(1100px,92%);margin-inline:auto}
     header.dng-header{position:sticky;top:0;z-index:1000;background:rgba(11,13,15,.85);backdrop-filter:blur(10px);border-bottom:1px solid rgba(255,255,255,.06)}
@@ -95,14 +104,26 @@
   </style>
 </head>
 <body>
-  <header class="dng-header">
+    <header class="dng-header">
     <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> -->
+      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span>
+        <button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </a>
+      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>
+        <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+        <!-- <a href="../support-formular.html">Support</a> -->
+      </nav>
       <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a> --></nav></aside>
+
 
   <main class="container">
     <article class="article">
@@ -214,6 +235,7 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
+  <script src="../js/theme-toggle.js"></script>
   <script>
     (function(){
       const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;

--- a/frontend/blog/bienengift-gelenkcreme.html
+++ b/frontend/blog/bienengift-gelenkcreme.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Bienengift Gelenkcreme – Natürliche Hilfe für Muskeln & Gelenke</title>
@@ -8,7 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
-    :root{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="dark"]{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="light"]{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 8px 24px rgba(15,23,42,.06)}
+    #themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto}
+    @media (min-width:821px){#themeToggleMobile{display:none!important}#themeToggleDesktop{display:inline-grid!important;margin-left:8px}}
+    @media (max-width:820px){#themeToggleDesktop{display:none!important}#themeToggleMobile{display:inline-grid!important;margin-left:6px!important;margin-top:0!important}}
+    .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15)}
+    .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff}
+    .theme-toggle-btn .icon{display:none}
+    html[data-theme="light"] .theme-toggle-btn .sun{display:block}
+    html[data-theme="dark"] .theme-toggle-btn .moon{display:block}
     *{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
     img{max-width:100%;display:block;border-radius:12px}a{text-decoration:none;color:inherit}.container{width:min(1100px,92%);margin-inline:auto}
     header.dng-header{position:sticky;top:0;z-index:1000;background:rgba(11,13,15,.85);backdrop-filter:blur(10px);border-bottom:1px solid rgba(255,255,255,.06)}
@@ -95,14 +104,25 @@
   </style>
 </head>
 <body>
-  <header class="dng-header">
+    <header class="dng-header">
     <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> -->
+      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span>
+        <button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </a>
+      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>
+        <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+        <!-- <a href="../support-formular.html">Support</a> -->
+      </nav>
       <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a> --></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -207,6 +227,7 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
+  <script src="../js/theme-toggle.js"></script>
   <script>
     (function(){
       const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;

--- a/frontend/blog/bloguebersicht.html
+++ b/frontend/blog/bloguebersicht.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head><!-- TrustBox script -->
 <script type="text/javascript" src="//widget.trustpilot.com/bootstrap/v5/tp.widget.bootstrap.min.js" async></script>
 <!-- End TrustBox script -->
@@ -1381,117 +1381,6 @@ html[data-theme="light"] .trustpilot-dark a {
       menu.querySelectorAll('a').forEach(a => a.addEventListener('click', closeMenu));
     })();
   </script>
-  <script>
-  (function(){
-    const STORAGE_KEY = 'theme';
-    // Der Theme-Button existiert nun in Desktop- und Mobile-Version. Wir sammeln beide.
-    const toggleBtns = document.querySelectorAll('#themeToggleDesktop, #themeToggleMobile');
-
-    // Wunsch: HELL als Primär
-    // 1) Aus localStorage holen
-    let saved = localStorage.getItem(STORAGE_KEY);
-
-    // 2) Wenn nichts gespeichert: standardmäßig light
-    let theme = (saved === 'dark' || saved === 'light') ? saved : 'light';
-    applyTheme(theme);
-
-    function applyTheme(next){
-      const themeVal = next === 'dark' ? 'dark' : 'light';
-      document.documentElement.setAttribute('data-theme', themeVal);
-      localStorage.setItem(STORAGE_KEY, themeVal);
-      const isDark = themeVal === 'dark';
-      // A11y: für alle Buttons den aria-pressed Zustand synchronisieren
-      toggleBtns.forEach(btn => btn.setAttribute('aria-pressed', String(isDark)));
-    }
-
-    // Klick-Handler für alle Theme-Toggles
-    toggleBtns.forEach(btn => {
-      btn.addEventListener('click', () => {
-        const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
-        const next = current === 'dark' ? 'light' : 'dark';
-        applyTheme(next);
-      });
-    });
-  })();
-</script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  return; // deaktiviert das alte pressed-Script
-  const t = document.getElementById('themeToggle');
-  if (!t) return;
-  let timer;
-  t.addEventListener('touchstart', () => {
-    t.classList.add('pressed');
-    clearTimeout(timer);
-    timer = setTimeout(() => t.classList.remove('pressed'), 180);
-  }, {passive:true});
-});
-document.addEventListener('DOMContentLoaded', () => {
-  return; // deaktiviert das alte Placement-Script (Brand/Nav)
-  return; // deaktiviert das alte Placement-Script (toMobile/toDesktop)
-  return; // deaktiviert das alte toMobile/toDesktop Placement-Script
-  const btn   = document.getElementById('themeToggle');
-  const links = document.querySelector('.dng-links');
-  const brand = document.querySelector('.dng-brand'); // Logo-Link
-
-  if (!btn || !links || !brand) return;
-
-  const mq = window.matchMedia('(max-width: 820px)');
-
-  const placeForMobile = () => {
-    // unter das Logo verschieben (direkt nach .dng-brand)
-    brand.insertAdjacentElement('afterend', btn);
-    btn.classList.add('is-mobile-pos');
-  };
-
-  const placeForDesktop = () => {
-    // zurück ins Nav neben "Über uns"
-    links.appendChild(btn);
-    btn.classList.remove('is-mobile-pos');
-  };
-
-  const updatePlacement = () => (mq.matches ? placeForMobile() : placeForDesktop());
-
-  mq.addEventListener ? mq.addEventListener('change', updatePlacement)
-                      : mq.addListener(updatePlacement); // ältere iOS
-
-  updatePlacement(); // initial
-});
-document.addEventListener('DOMContentLoaded', () => {
-  const btn   = document.getElementById('themeToggle');
-  const brand = document.querySelector('.dng-brand');   // Logo + Text
-  const links = document.querySelector('.dng-links');   // Desktop-Navigation
-  if (!btn || !brand || !links) return;
-
-  const mq = window.matchMedia('(max-width: 820px)');
-
-  const toMobile = () => {
-    // direkt RECHTS neben dem "DropNGo"-Titel
-    brand.insertAdjacentElement('afterend', btn);
-    btn.classList.add('is-mobile-inline');
-  };
-
-  const toDesktop = () => {
-    // zurück in die Desktop-Linkleiste (neben "Über uns")
-    links.appendChild(btn);
-    btn.classList.remove('is-mobile-inline');
-  };
-
-  const place = () => (mq.matches ? toMobile() : toDesktop());
-  mq.addEventListener ? mq.addEventListener('change', place) : mq.addListener(place);
-  place();
-  
-    // verhindert festhängenden :hover/:focus auf iOS
-    btn.blur();
- // Auf Touch: auch sicher den Fokus lösen
-  btn.addEventListener('touchend',   () => btn.blur(), { passive: true });
-  btn.addEventListener('touchcancel',() => btn.blur(), { passive: true });
-  /* ---------- 3) KLICKBARKEIT absichern (falls CSS woanders hakt) ---------- */
-  btn.type = 'button';
-  btn.style.pointerEvents = 'auto';
-  btn.style.position = btn.style.position || 'relative';
-  btn.style.zIndex = btn.style.zIndex || '5';
-});
-</script>
+  <script src="../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/frontend/blog/glueckstoff-orthopaedisches-kissen.html
+++ b/frontend/blog/glueckstoff-orthopaedisches-kissen.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Glückstoff® Orthopädisches Kissen – Erholsam schlafen, Nacken entlasten</title>
@@ -8,7 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
-    :root{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="dark"]{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="light"]{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 8px 24px rgba(15,23,42,.06)}
+    #themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto}
+    @media (min-width:821px){#themeToggleMobile{display:none!important}#themeToggleDesktop{display:inline-grid!important;margin-left:8px}}
+    @media (max-width:820px){#themeToggleDesktop{display:none!important}#themeToggleMobile{display:inline-grid!important;margin-left:6px!important;margin-top:0!important}}
+    .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15)}
+    .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff}
+    .theme-toggle-btn .icon{display:none}
+    html[data-theme="light"] .theme-toggle-btn .sun{display:block}
+    html[data-theme="dark"] .theme-toggle-btn .moon{display:block}
     *{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
     img{max-width:100%;display:block;border-radius:12px}a{text-decoration:none;color:inherit}.container{width:min(1100px,92%);margin-inline:auto}
     header.dng-header{position:sticky;top:0;z-index:1000;background:rgba(11,13,15,.85);backdrop-filter:blur(10px);border-bottom:1px solid rgba(255,255,255,.06)}
@@ -95,14 +104,25 @@
   </style>
 </head>
 <body>
-  <header class="dng-header">
+    <header class="dng-header">
     <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> -->
+      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span>
+        <button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </a>
+      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>
+        <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+        <!-- <a href="../support-formular.html">Support</a> -->
+      </nav>
       <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a> --></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -207,6 +227,7 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
+  <script src="../js/theme-toggle.js"></script>
   <script>
     (function(){
       const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;

--- a/frontend/blog/sanotact-elektrolyte.html
+++ b/frontend/blog/sanotact-elektrolyte.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="de">
+<html lang="de" data-theme="light">
 <head>
   <meta charset="UTF-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>Sanotact Elektrolyte Plus – Schnelle Regeneration</title>
@@ -8,7 +8,16 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <style>
-    :root{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="dark"]{--bg:#0b0d0f;--surface:#121417;--elev:#191c20;--text:#e6e9ee;--muted:#aab3be;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 10px 30px rgba(0,0,0,.35)}
+    html[data-theme="light"]{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--brand:#18a196;--brand-700:#0e9d90;--radius:14px;--shadow:0 8px 24px rgba(15,23,42,.06)}
+    #themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto}
+    @media (min-width:821px){#themeToggleMobile{display:none!important}#themeToggleDesktop{display:inline-grid!important;margin-left:8px}}
+    @media (max-width:820px){#themeToggleDesktop{display:none!important}#themeToggleMobile{display:inline-grid!important;margin-left:6px!important;margin-top:0!important}}
+    .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15)}
+    .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff}
+    .theme-toggle-btn .icon{display:none}
+    html[data-theme="light"] .theme-toggle-btn .sun{display:block}
+    html[data-theme="dark"] .theme-toggle-btn .moon{display:block}
     *{box-sizing:border-box}body{margin:0;font-family:Inter,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--text);line-height:1.6}
     img{max-width:100%;display:block;border-radius:12px}a{text-decoration:none;color:inherit}.container{width:min(1100px,92%);margin-inline:auto}
     header.dng-header{position:sticky;top:0;z-index:1000;background:rgba(11,13,15,.85);backdrop-filter:blur(10px);border-bottom:1px solid rgba(255,255,255,.06)}
@@ -95,14 +104,25 @@
   </style>
 </head>
 <body>
-  <header class="dng-header">
+    <header class="dng-header">
     <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> -->
+      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span>
+        <button id="themeToggleMobile" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+        </button>
+      </a>
+      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>
+        <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
+          <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          <svg class="icon moon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+        <!-- <a href="../support-formular.html">Support</a> -->
+      </nav>
       <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a> --></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -203,6 +223,7 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
+  <script src="../js/theme-toggle.js"></script>
   <script>
     (function(){
       const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;

--- a/frontend/js/theme-toggle.js
+++ b/frontend/js/theme-toggle.js
@@ -1,0 +1,21 @@
+(function(){
+  const STORAGE_KEY = 'theme';
+  const toggleBtns = document.querySelectorAll('#themeToggleDesktop, #themeToggleMobile');
+  let saved = localStorage.getItem(STORAGE_KEY);
+  let theme = (saved === 'dark' || saved === 'light') ? saved : 'light';
+  applyTheme(theme);
+  function applyTheme(next){
+    const themeVal = next === 'dark' ? 'dark' : 'light';
+    document.documentElement.setAttribute('data-theme', themeVal);
+    localStorage.setItem(STORAGE_KEY, themeVal);
+    const isDark = themeVal === 'dark';
+    toggleBtns.forEach(btn => btn.setAttribute('aria-pressed', String(isDark)));
+  }
+  toggleBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const current = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+      const next = current === 'dark' ? 'light' : 'dark';
+      applyTheme(next);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- centralize theme switcher logic in `frontend/js/theme-toggle.js`
- enable light/dark variables and toggle buttons on all blog articles
- load new theme toggle script across blog pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b3376bdb788321827e6c9c1294b762