### PR TITLE
Refactor footers to four-column layout

### DIFF
--- a/frontend/agb.html
+++ b/frontend/agb.html
@@ -61,10 +61,13 @@
     .legal-card h2 { font-size: clamp(20px, 4vw, 28px); color: var(--brand); margin-top: 30px; margin-bottom: 10px; font-weight: 600; border-bottom: 1px solid rgba(255,255,255,.1); padding-bottom: 6px; }
     .legal-card p { color: var(--muted); margin-top: 12px; font-size: 0.95rem; line-height: 1.6; }
 
-    footer { padding: 40px 0; text-align: center; border-top: 1px solid rgba(255,255,255,.06); color: var(--muted); font-size: 14px; margin-top: 60px; }
-    .footer-links { display: flex; gap: 20px; justify-content: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .footer-links a { color: var(--muted); transition: var(--transition); }
-    .footer-links a:hover { color: var(--text); }
+    footer.site-footer{ margin-top: 60px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; padding: 26px 0; }
+    .footer-col h4{ margin:0 0 8px; font-size: 16px; color:#d7dde6; }
+    .footer-col a{ color:var(--muted); display:inline-block; padding:6px 0; }
+    .footer-col a:hover{ color:var(--text); }
+    .copyright{ color:#8f98a3; font-size: 14px; padding: 12px 0 32px; }
+    @media (max-width: 760px){ .footer-grid{ grid-template-columns: 1fr; } }
 
     @media(max-width:600px){
       .nav-links, .brand { width: 100%; text-align: center; margin-top: 10px; }
@@ -251,56 +254,79 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-links">
-      <a href="impressum.html">Impressum</a>
-      <a href="datenschutz.html">Datenschutz</a>
-      <a href="agb.html" style="color: var(--text);">AGB</a>
+    <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
     </div>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
     <div class="container">
-      <p>&copy; 2025 DropNGo – Alle Rechte vorbehalten. Hinweis: DropNGo vermittelt Produkte
-        externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen
-        Händler.</p>
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
     </div>
-      <!-- ===== Scripts ===== -->
-  <script>
-    // Mobile menu toggle
-   
-
-    // Active link markieren
-    (function(){
-      const path = location.pathname.split('/').pop() || 'index.html';
-      document.querySelectorAll('.nav__links a, .mobile-menu a').forEach(a => {
-        if (a.getAttribute('href') === path) a.setAttribute('aria-current','page');
-      });
-    })();
-
-    // Thumbnails -> Hero wechseln
-    const heroImg = document.getElementById('heroImg');
-    document.querySelectorAll('.thumbs [data-src]').forEach(t => {
-      t.addEventListener('click', () => {
-        const src = t.getAttribute('data-src');
-        if (src && heroImg) heroImg.setAttribute('src', src);
-      });
-    });
-
-    // Tabs
-    const tabButtons = document.querySelectorAll('.tab-head button');
-    const panels = {
-      desc: document.getElementById('tab-desc'),
-      features: document.getElementById('tab-features'),
-      shipping: document.getElementById('tab-shipping')
-    };
-    tabButtons.forEach(btn => {
-      btn.addEventListener('click', () => {
-        tabButtons.forEach(b => b.setAttribute('aria-selected','false'));
-        Object.values(panels).forEach(p => p?.setAttribute('data-active','false'));
-        btn.setAttribute('aria-selected','true');
-        const key = btn.dataset.tab;
-        panels[key]?.setAttribute('data-active','true');
-      });
-    });
-  </script>
   </footer>
   <script defer src="js/script.js"></script>
   <script src="js/auth-config.js"></script>               <!-- falls benötigt -->

--- a/frontend/blog/bloguebersicht.html
+++ b/frontend/blog/bloguebersicht.html
@@ -1092,13 +1092,6 @@ html[data-theme="dark"]  .theme-toggle { color: #e6e9ee; }
   box-shadow: 0 -4px 12px rgba(0,0,0,0.08);
 }
 
-[data-theme="light"] .footer-links a {
-  color: #333;
-}
-
-[data-theme="light"] .footer-links a:hover {
-  color: #18a196; /* deine Akzentfarbe */
-}
 /* Titel "DropNGo" im hellen Layout komplett schwarz */
 [data-theme="light"] .dng-brand-text {
   color: #000 !important;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -253,11 +253,6 @@ main:hover {
 }
 
 /* Responsive */
-@media (max-width: 600px) {
-  .products {
-    gap: 15px;
-    padding: 20px 10px;
-  }
 
   .product {
     width: 90vw;
@@ -469,30 +464,10 @@ footer {
   box-shadow: 0 -2px 10px rgba(0, 255, 136, 0.2);
 }
 
-.footer-links {
-  margin-bottom: 15px;
-}
-
-.footer-links a {
-  margin: 0 15px;
-  color: rgb(24, 161, 150);
-  text-decoration: none;
-  font-weight: bold;
-  transition: color 0.3s ease, text-shadow 0.3s ease;
-}
-
-.footer-links a:hover {
-  color: white;
-  text-shadow: 0 0 10px rgb(24, 161, 150);
-}
 
 
-@media (max-width: 600px) {
-  .footer-links a {
-    display: block;
-    margin: 10px 0;
-  }
-}
+
+
 
 .home-btn {
   display: inline-block;
@@ -579,10 +554,6 @@ footer {
   text-shadow: 0 0 10px rgb(24, 161, 150);
 }
 
-@media (max-width: 600px) {
-  .footer-contact {
-    text-align: center;
-  }
 }
 
 
@@ -1153,18 +1124,6 @@ footer {
 }
 
 /* Responsive: Bei kleinen Bildschirmen Sidebar oben als horizontale Leiste */
-@media (max-width: 600px) {
-  .sidebar {
-    position: relative;
-    width: 100%;
-    height: auto;
-    flex-direction: row;
-    justify-content: center;
-    padding: 15px 0;
-    box-shadow: none;
-    backdrop-filter: none;
-    background: rgba(0,0,0,0.7);
-  }
   .sidebar button {
     width: auto;
     flex: 1;

--- a/frontend/datenschutz.html
+++ b/frontend/datenschutz.html
@@ -60,10 +60,13 @@
     .legal-card a { color: var(--brand); text-decoration: underline; }
     .legal-card a:hover { color: var(--brand-hover); }
 
-    footer { padding: 40px 0; text-align: center; border-top: 1px solid rgba(255,255,255,.06); color: var(--muted); font-size: 14px; margin-top: 60px; }
-    .footer-links { display: flex; gap: 20px; justify-content: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .footer-links a { color: var(--muted); transition: var(--transition); }
-    .footer-links a:hover { color: var(--text); }
+    footer.site-footer{ margin-top: 60px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; padding: 26px 0; }
+    .footer-col h4{ margin:0 0 8px; font-size: 16px; color:#d7dde6; }
+    .footer-col a{ color:var(--muted); display:inline-block; padding:6px 0; }
+    .footer-col a:hover{ color:var(--text); }
+    .copyright{ color:#8f98a3; font-size: 14px; padding: 12px 0 32px; }
+    @media (max-width: 760px){ .footer-grid{ grid-template-columns: 1fr; } }
 
     @media(max-width:600px){
       .nav-links, .brand { width: 100%; text-align: center; margin-top: 10px; }
@@ -255,17 +258,81 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-links">
-      <a href="impressum.html">Impressum</a>
-      <a href="datenschutz.html" style="color: var(--text);">Datenschutz</a>
-      <a href="agb.html">AGB</a>
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
     </div>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
     <div class="container">
-      <p>&copy; 2025 DropNGo – Alle Rechte vorbehalten. Hinweis: DropNGo vermittelt Produkte
-        externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen
-        Händler.</p>
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
     </div>
+  </footer>
+
       <!-- ===== Scripts ===== -->
   <script>
     // Mobile menu toggle

--- a/frontend/impressum.html
+++ b/frontend/impressum.html
@@ -61,10 +61,13 @@
     .legal-card a { color: var(--brand); text-decoration: underline; }
     .legal-card a:hover { color: var(--brand-hover); }
 
-    footer { padding: 40px 0; text-align: center; border-top: 1px solid rgba(255,255,255,.06); color: var(--muted); font-size: 14px; margin-top: 60px; }
-    .footer-links { display: flex; gap: 20px; justify-content: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .footer-links a { color: var(--muted); transition: var(--transition); }
-    .footer-links a:hover { color: var(--text); }
+    footer.site-footer{ margin-top: 60px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; padding: 26px 0; }
+    .footer-col h4{ margin:0 0 8px; font-size: 16px; color:#d7dde6; }
+    .footer-col a{ color:var(--muted); display:inline-block; padding:6px 0; }
+    .footer-col a:hover{ color:var(--text); }
+    .copyright{ color:#8f98a3; font-size: 14px; padding: 12px 0 32px; }
+    @media (max-width: 760px){ .footer-grid{ grid-template-columns: 1fr; } }
 
     @media(max-width:600px){
       .nav-links, .brand { width: 100%; text-align: center; margin-top: 10px; }
@@ -268,17 +271,81 @@
     </div>
   </main>
 
-  <footer>
-    <div class="container footer-links">
-      <a href="impressum.html" style="color: var(--text);">Impressum</a>
-      <a href="datenschutz.html">Datenschutz</a>
-      <a href="agb.html">AGB</a>
+  <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
     </div>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
     <div class="container">
-      <p>&copy; 2025 DropNGo – Alle Rechte vorbehalten. Hinweis: DropNGo vermittelt Produkte
-        externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen
-        Händler.</p>
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
     </div>
+  </footer>
+
       <!-- ===== Scripts ===== -->
   <script>
     // Mobile menu toggle

--- a/frontend/info.html
+++ b/frontend/info.html
@@ -70,10 +70,13 @@
     .about-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 40px; }
 
     /* Footer */
-    footer { padding: 40px 0; text-align: center; border-top: 1px solid rgba(255,255,255,.06); color: var(--muted); font-size: 14px; margin-top: 80px; }
-    .footer-links { display: flex; gap: 20px; justify-content: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .footer-links a { color: var(--muted); transition: var(--transition); }
-    .footer-links a:hover { color: var(--text); }
+    footer.site-footer{ margin-top: 80px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e; }
+    .footer-grid{ display:grid; grid-template-columns: 2fr 1fr 1fr 1fr; gap:18px; padding: 26px 0; }
+    .footer-col h4{ margin:0 0 8px; font-size: 16px; color:#d7dde6; }
+    .footer-col a{ color:var(--muted); display:inline-block; padding:6px 0; }
+    .footer-col a:hover{ color:var(--text); }
+    .copyright{ color:#8f98a3; font-size: 14px; padding: 12px 0 32px; }
+    @media (max-width: 760px){ .footer-grid{ grid-template-columns: 1fr; } }
 
     @media(max-width:600px){
       .nav-links, .brand { width: 100%; text-align: center; margin-top: 10px; }
@@ -145,36 +148,30 @@
   header.site-header { z-index: 10001; }              /* Header unter Menü */
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
-.footer-social svg {
   width: 20px;
   height: 20px;
   flex-shrink: 0;
 }
-.footer-social a {
   display: inline-flex;
   align-items: center;
   gap: 6px;
   color: var(--muted);
   transition: color .2s;
 }
-.footer-social a:hover {
   color: var(--text);
 }
-.footer-links {
   display: flex;
   gap: 20px;
   justify-content: center;
   margin-bottom: 14px;
 }
 
-.footer-social {
   display: flex;
   gap: 20px;
   justify-content: center;
   margin-bottom: 14px;
 }
 
-.footer-social a {
   color: var(--muted);
   display: inline-flex;
   align-items: center;
@@ -182,11 +179,9 @@
   transition: color 0.2s ease;
 }
 
-.footer-social a:hover {
   color: var(--text);
 }
 
-.footer-social svg {
   width: 18px;
   height: 18px;
 }
@@ -1223,11 +1218,9 @@ html[data-theme="dark"]  .theme-toggle { color: #e6e9ee; }
   box-shadow: 0 -4px 12px rgba(0,0,0,0.08);
 }
 
-[data-theme="light"] .footer-links a {
   color: #333;
 }
 
-[data-theme="light"] .footer-links a:hover {
   color: #18a196; /* deine Akzentfarbe */
 }
 /* Titel "DropNGo" im hellen Layout komplett schwarz */
@@ -1381,27 +1374,39 @@ html[data-theme="dark"]  .theme-toggle { color: #e6e9ee; }
   </section>
 
   <!-- Footer -->
-<footer>
-  <div class="container">
-    <!-- Footer-Links -->
-    <div class="footer-links">
-      <a href="impressum.html">Impressum</a>
-      <a href="datenschutz.html">Datenschutz</a>
+<footer class="site-footer">
+  <div class="container footer-grid">
+    <div class="footer-col">
+      <h4>DropNGo</h4>
+      <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+    </div>
+
+    <div class="footer-col">
+      <h4>Rechtliches</h4>
+      <a href="impressum.html">Impressum</a><br/>
+      <a href="datenschutz.html">Datenschutz</a><br/>
       <a href="agb.html">AGB</a>
     </div>
 
-    <!-- Social Media mittig -->
-    <div class="footer-social">
-      <a href="https://www.instagram.com/dropngo.shop" target="_blank" aria-label="Instagram">Instagram</a>
-      <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" aria-label="TikTok">TikTok</a>
+    <div class="footer-col">
+      <h4>Kontakt</h4>
+      <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+      <!-- <a href="support-formular.html">Support</a> -->
     </div>
+
+    <div class="footer-col">
+      <h4>Folge uns</h4>
+      <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+      <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+    </div>
+  </div>
 <!-- TrustBox widget - Review Collector -->
-<div class="trustpilot-widget trustpilot-dark" 
-     data-locale="de-DE" 
-     data-template-id="56278e9abfbbba0bdcd568bc" 
-     data-businessunit-id="68b1c25fbc94b86a86ac2baa" 
-     data-style-height="52px" 
-     data-style-width="100%" 
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
      data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
   <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
 </div>
@@ -1439,13 +1444,8 @@ html[data-theme="dark"]  .theme-toggle { color: #e6e9ee; }
   }
 </style>
 
-
-    <!-- Copyright -->
-    <p class="copyright">
-      &copy; 2025 DropNGo – Alle Rechte vorbehalten. 
-      Hinweis: DropNGo vermittelt Produkte externer Anbieter. 
-      Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.
-    </p>
+  <div class="container">
+    <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
   </div>
 </footer>
 

--- a/frontend/products.html
+++ b/frontend/products.html
@@ -88,9 +88,6 @@
     footer { padding: 40px 0; text-align: center; border-top: 1px solid rgba(255,255,255,.06); color: var(--muted); font-size: 14px; }
 
     /* Footer Links */
-    .footer-links { display: flex; gap: 20px; justify-content: center; margin-bottom: 12px; flex-wrap: wrap; }
-    .footer-links a { color: var(--muted); transition: var(--transition); }
-    .footer-links a:hover { color: var(--text); }
 
     /* Responsive Mobile */
     @media(max-width:600px){
@@ -221,20 +218,6 @@ footer{
   background:#0a0c0e;
   color:var(--muted);
   font-size:14px;
-}
-.footer-links{
-  display:flex; gap:16px; justify-content:center; flex-wrap:wrap; margin-bottom:10px;
-}
-.footer-links a{
-  color:var(--muted);
-  padding:6px 10px; border-radius:8px;
-  transition:color .2s ease, background .2s ease;
-  position:relative;
-}
-.footer-links a:hover{ color:var(--text); background:rgba(255,255,255,.06); }
-.footer-links a + a::before{
-  content:""; position:absolute; left:-8px; top:50%; transform:translate(-50%,-50%);
-  width:4px; height:4px; border-radius:50%; background:rgba(255,255,255,.25);
 }
 footer p{ max-width:900px; margin:8px auto 0; line-height:1.6; }
 /* Footer – identisch zur Startseite */

--- a/frontend/reset.html
+++ b/frontend/reset.html
@@ -222,6 +222,13 @@
 
 
 
+      footer.site-footer{margin-top:60px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e}
+    .footer-grid{display:grid; grid-template-columns:2fr 1fr 1fr 1fr; gap:18px; padding:26px 0}
+    .footer-col h4{margin:0 0 8px; font-size:16px; color:#d7dde6}
+    .footer-col a{color:var(--muted); display:inline-block; padding:6px 0}
+    .footer-col a:hover{color:var(--text)}
+    .copyright{color:#8f98a3; font-size:14px; padding:12px 0 32px}
+    @media (max-width:760px){.footer-grid{grid-template-columns:1fr}}
   </style>
 </head>
 <body>
@@ -324,8 +331,79 @@
     </section>
   </main>
 
-  <footer>
-    <div class="container">© 2025 DropNGo – Sicher, fair & transparent.</div>
+    <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Sicher, fair & transparent.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
+    </div>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
+    <div class="container">
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+    </div>
   </footer>
 
   <!-- Keys (liefert window.SUPABASE_URL / window.SUPABASE_ANON) -->

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -361,30 +361,10 @@ footer {
   box-shadow: 0 -2px 10px rgba(0, 255, 136, 0.2);
 }
 
-.footer-links {
-  margin-bottom: 15px;
-}
-
-.footer-links a {
-  margin: 0 15px;
-  color: rgb(24, 161, 150);
-  text-decoration: none;
-  font-weight: bold;
-  transition: color 0.3s ease, text-shadow 0.3s ease;
-}
-
-.footer-links a:hover {
-  color: white;
-  text-shadow: 0 0 10px rgb(24, 161, 150);
-}
 
 
-@media (max-width: 600px) {
-  .footer-links a {
-    display: block;
-    margin: 10px 0;
-  }
-}
+
+
 
 .home-btn {
   display: inline-block;
@@ -471,10 +451,6 @@ footer {
   text-shadow: 0 0 10px rgb(24, 161, 150);
 }
 
-@media (max-width: 600px) {
-  .footer-contact {
-    text-align: center;
-  }
 }
 
 
@@ -993,18 +969,6 @@ footer {
 }
 
 /* Responsive: Bei kleinen Bildschirmen Sidebar oben als horizontale Leiste */
-@media (max-width: 600px) {
-  .sidebar {
-    position: relative;
-    width: 100%;
-    height: auto;
-    flex-direction: row;
-    justify-content: center;
-    padding: 15px 0;
-    box-shadow: none;
-    backdrop-filter: none;
-    background: rgba(0,0,0,0.7);
-  }
   .sidebar button {
     width: auto;
     flex: 1;

--- a/frontend/support-formular.html
+++ b/frontend/support-formular.html
@@ -61,10 +61,13 @@
     .form button:hover{background:var(--brand-hover)}
     #response{margin-top:14px; font-weight:600; text-align:center}
 
-    footer{padding:40px 0; text-align:center; border-top:1px solid rgba(255,255,255,.06); color:var(--muted); font-size:14px; margin-top:60px}
-    .footer-links{display:flex; gap:20px; justify-content:center; margin-bottom:12px; flex-wrap:wrap}
-    .footer-links a{color:var(--muted)}
-    .footer-links a:hover{color:var(--text)}
+    footer.site-footer{margin-top:60px; border-top:1px solid rgba(255,255,255,.06); background:#0a0c0e}
+    .footer-grid{display:grid; grid-template-columns:2fr 1fr 1fr 1fr; gap:18px; padding:26px 0}
+    .footer-col h4{margin:0 0 8px; font-size:16px; color:#d7dde6}
+    .footer-col a{color:var(--muted); display:inline-block; padding:6px 0}
+    .footer-col a:hover{color:var(--text)}
+    .copyright{color:#8f98a3; font-size:14px; padding:12px 0 32px}
+    @media (max-width:760px){.footer-grid{grid-template-columns:1fr}}
 
     @media(max-width:600px){ .form{padding:30px 20px} }
   </style>
@@ -126,19 +129,78 @@
     </form>
   </main>
 
-  <footer>
-    <div class="container footer-links">
-      <a href="impressum.html">Impressum</a>
-      <a href="datenschutz.html">Datenschutz</a>
-      <a href="agb.html">AGB</a>
-    </div> <div class="footer-col">
-      <h4>Social Media</h4>
-      <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a>
-      <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+    <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
     </div>
-  </div>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
     <div class="container">
-      <p>&copy; 2025 DropNGo – Alle Rechte vorbehalten. Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
     </div>
   </footer>
 

--- a/frontend/widerrufsbelehrung.html
+++ b/frontend/widerrufsbelehrung.html
@@ -77,30 +77,13 @@
     a:hover {
       color: rgb(24, 161, 150);
     }
-    footer {
-      max-width: 720px;
-      margin: 40px auto 20px;
-      text-align: center;
-      color: rgb(24, 161, 150);
-      font-size: 0.9rem;
-      flex-shrink: 0;
-    }
-    .footer-links {
-      margin-bottom: 10px;
-      display: flex;
-      justify-content: center;
-      gap: 30px;
-      flex-wrap: wrap;
-    }
-    .footer-links a {
-      color: rgb(24, 161, 150);
-      text-decoration: underline;
-      font-weight: 600;
-      transition: color 0.3s ease;
-    }
-    .footer-links a:hover {
-      color: rgb(24, 161, 150);
-    }
+    footer.site-footer{margin-top:40px;border-top:1px solid rgba(255,255,255,.06);background:#0a0c0e;color:#aab3be;font-size:0.9rem;}
+    .footer-grid{display:grid;grid-template-columns:2fr 1fr 1fr 1fr;gap:18px;padding:26px 0;}
+    .footer-col h4{margin:0 0 8px;font-size:16px;color:#d7dde6;}
+    .footer-col a{color:rgb(24,161,150);display:inline-block;padding:6px 0;text-decoration:underline;font-weight:600;}
+    .footer-col a:hover{color:#fff;}
+    .copyright{color:#8f98a3;font-size:14px;padding:12px 0 32px;}
+    @media(max-width:760px){.footer-grid{grid-template-columns:1fr;}}
   </style>
 </head>
 <body>
@@ -125,13 +108,79 @@
     </section>
   </main>
 
-  <footer>
-    <div class="footer-links">
-      <a href="impressum.html">Impressum</a>
-      <a href="datenschutz.html">Datenschutz</a>
-      <a href="agb.html">AGB</a>
+    <footer class="site-footer">
+    <div class="container footer-grid">
+      <div class="footer-col">
+        <h4>DropNGo</h4>
+        <p class="meta">Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+      </div>
+
+      <div class="footer-col">
+        <h4>Rechtliches</h4>
+        <a href="impressum.html">Impressum</a><br/>
+        <a href="datenschutz.html">Datenschutz</a><br/>
+        <a href="agb.html">AGB</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Kontakt</h4>
+        <a href="mailto:kontakt@dropngo.shop">kontakt@dropngo.shop</a><br/>
+        <!-- <a href="support-formular.html">Support</a> -->
+      </div>
+
+      <div class="footer-col">
+        <h4>Folge uns</h4>
+        <a href="https://www.instagram.com/dropngo.shop" target="_blank" rel="noopener">Instagram</a><br/>
+        <a href="https://www.tiktok.com/@dropngo.shop" target="_blank" rel="noopener">TikTok</a>
+      </div>
     </div>
-    <p>&copy; 2025 DropNGo – Alle Rechte vorbehalten.</p>
+<!-- TrustBox widget - Review Collector -->
+<div class="trustpilot-widget trustpilot-dark"
+     data-locale="de-DE"
+     data-template-id="56278e9abfbbba0bdcd568bc"
+     data-businessunit-id="68b1c25fbc94b86a86ac2baa"
+     data-style-height="52px"
+     data-style-width="100%"
+     data-token="134582dc-89e6-4eaa-9938-6d937d8901bc">
+  <a href="https://de.trustpilot.com/review/www.dropngo.shop" target="_blank" rel="noopener">Trustpilot</a>
+</div>
+<!-- End TrustBox widget -->
+
+<style>
+  /* Dark-Theme: schwarz wie bisher */
+  html[data-theme="dark"] .trustpilot-dark {
+    background-color: #121212 !important;
+    border: 1px solid #2a2a2a !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a {
+    color: #00b67a !important;
+    font-weight: 700 !important;
+    text-decoration: none !important;
+    font-size: 14px !important;
+  }
+  html[data-theme="dark"] .trustpilot-dark a:hover { color: #1ed760 !important; }
+
+  /* Light-Theme: weiße Box */
+  html[data-theme="light"] .trustpilot-dark {
+    background-color: #ffffff !important;
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px !important;
+    padding: 12px !important;
+    text-align: center !important;
+    box-shadow: 0 4px 12px rgba(0,0,0,.08) !important;
+  }
+  html[data-theme="light"] .trustpilot-dark a {
+    color: #000 !important;
+    font-weight: 600 !important;
+  }
+</style>
+
+    <div class="container">
+      <p class="copyright">© 2025 DropNGo – Alle Rechte vorbehalten. | Hinweis: DropNGo vermittelt Produkte externer Anbieter. Kaufverträge entstehen zwischen Kund:innen und dem jeweiligen Händler.</p>
+    </div>
   </footer>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace legacy footers on legal and info pages with shared four-column footer
- retain page-specific descriptions and add legal, contact, and social links
- remove obsolete `.footer-links` styles from HTML and CSS

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b541ee6bc88321868b6903ca8f0235