### PR TITLE
refactor: externalize Danke page styles

### DIFF
--- a/frontend/css/mobile.css
+++ b/frontend/css/mobile.css
@@ -127,3 +127,43 @@ a.btn, .btn{ min-height:44px; min-width:44px; }
   .price{ font-size: 14.5px; }
   .quote{ padding:12px; }
 }
+
+/* Danke page */
+.danke-page {
+  font-family: 'Inter', sans-serif;
+  background-color: #0b0d0f;
+  color: #e6e9ee;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+  flex-direction: column;
+  text-align: center;
+}
+
+.danke-page h1 {
+  font-size: clamp(2rem, 5vw, 2.5rem);
+  margin-bottom: 12px;
+  color: #18a196;
+}
+
+.danke-page p {
+  font-size: clamp(1rem, 2.5vw, 1.1rem);
+  color: #aab3be;
+}
+
+.danke-page a {
+  margin-top: 30px;
+  padding: clamp(8px, 2vh, 10px) clamp(16px, 5vw, 24px);
+  background-color: #18a196;
+  color: #041413;
+  text-decoration: none;
+  border-radius: 12px;
+  font-weight: 600;
+  transition: 0.3s ease;
+}
+
+.danke-page a:hover {
+  background-color: #0e9d90;
+}

--- a/frontend/danke.html
+++ b/frontend/danke.html
@@ -7,44 +7,9 @@
   <title>Danke | DropNGo</title>
   <link rel="icon" href="assets/favicon.ico" />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <style>
-    body {
-      font-family: 'Inter', sans-serif;
-      background-color: #0b0d0f;
-      color: #e6e9ee;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      flex-direction: column;
-      text-align: center;
-    }
-    h1 {
-      font-size: 2.5rem;
-      margin-bottom: 12px;
-      color: #18a196;
-    }
-    p {
-      font-size: 1.1rem;
-      color: #aab3be;
-    }
-    a {
-      margin-top: 30px;
-      padding: 10px 24px;
-      background-color: #18a196;
-      color: #041413;
-      text-decoration: none;
-      border-radius: 12px;
-      font-weight: 600;
-      transition: 0.3s ease;
-    }
-    a:hover {
-      background-color: #0e9d90;
-    }
-  </style>
+  <link rel="stylesheet" href="css/mobile.css">
 </head>
-<body>
+<body class="danke-page">
   <h1>Vielen Dank!</h1>
   <p>Du hast dich Erfolgreich registriert.<br>Hier unten kannst du zur Startseite zurück.</p>
   <a href="index.html">Zurück zur Startseite</a>


### PR DESCRIPTION
## Summary
- load `frontend/css/mobile.css` on Danke page
- move Danke page styling into mobile stylesheet using `clamp`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b545009f14832198616204e9158e13