### PR TITLE
Fix mobile menu and theme toggle across pages

### DIFF
--- a/frontend/01-beurer-br-60-insektenstichheiler.html
+++ b/frontend/01-beurer-br-60-insektenstichheiler.html
@@ -298,7 +298,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
-   <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -566,10 +566,9 @@
 <script defer src="js/account-slot.js"></script>        <!-- Pfad anpassen -->
 
 
-</script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
- <script src="../js/theme.js" defer></script>
+ <script src="js/theme.js" defer></script>
      <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/agb.html
+++ b/frontend/agb.html
@@ -141,7 +141,7 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-   <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -365,7 +365,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
 
   <!-- Cookie banner: placeholder and script injection -->
   <div id="cookieBanner"></div>

--- a/frontend/blog/beurer-br60-insektenstichheiler.html
+++ b/frontend/blog/beurer-br60-insektenstichheiler.html
@@ -172,9 +172,10 @@
     <link rel="stylesheet" href="../css/theme.css">
 </head>
 <body>
-  <header class="dng-header">
-    <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>  <!-- Mobile Theme Toggle (hidden on desktop) -->
+  <header class="dng-header" data-mobile>
+    <div class="dng-container dng-nav">
+      <a class="dng-brand" href="../index.html" aria-label="DropNGo Startseite"><img class="dng-logo" src="../favicon.ico" alt=""><span class="dng-brand-text">DropNGo</span></a>
+      <!-- Mobile Theme Toggle (hidden on desktop) -->
     <!--
       We remove the generic `theme-toggle` class here and use a unique class `theme-toggle-btn`.
       This prevents our mobile toggle from being hidden by legacy CSS rules targeting `.theme-toggle`.
@@ -191,27 +192,27 @@
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
       </svg>
     </button>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
+      <nav class="dng-links" aria-label="Hauptnavigation"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
 <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
   <!-- Sonne (outline) -->
   <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
   </svg>
-<!-- Mond Outline -->
-<svg class="icon moon" xmlns="http://www.w3.org/2000/svg" 
-     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" 
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 12.79A9 9 0 1 1 11.21 3 
-           7 7 0 0 0 21 12.79z"/>
-</svg>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
 </button>
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
-      <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+      <button id="dngNavToggle" class="dng-burger" aria-expanded="false" aria-controls="dngMobileMenu" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <div id="dngOverlay" class="dng-overlay" hidden></div>
+  <aside id="dngMobileMenu" class="dng-drawer" hidden aria-label="Mobile Navigation"><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -323,18 +324,9 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
-  <script>
-    (function(){
-      const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;
-      const open=()=>{menu.removeAttribute('hidden');btn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';};
-      const close=()=>{menu.setAttribute('hidden','');btn.setAttribute('aria-expanded','false');document.body.style.overflow='';};
-      btn.addEventListener('click',()=>btn.getAttribute('aria-expanded')==='true'?close():open());
-      document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
-      menu.querySelectorAll('a').forEach(a=>a.addEventListener('click',close));
-    })();
-  </script>
+  <script src="../js/mobile.js" defer></script>
   <script src="../js/theme.js" defer></script>
-    <div id="cookieBanner"></div>
+  <div id="cookieBanner"></div>
   <!-- Cookie banner script: relative path corrected to parent js folder -->
   <script src="../js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/blog/bienengift-gelenkcreme.html
+++ b/frontend/blog/bienengift-gelenkcreme.html
@@ -172,9 +172,10 @@
    <link rel="stylesheet" href="../css/theme.css">
 </head>
 <body>
-  <header class="dng-header">
-    <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>   <!-- Mobile Theme Toggle (hidden on desktop) -->
+  <header class="dng-header" data-mobile>
+    <div class="dng-container dng-nav">
+      <a class="dng-brand" href="../index.html" aria-label="DropNGo Startseite"><img class="dng-logo" src="../favicon.ico" alt=""><span class="dng-brand-text">DropNGo</span></a>
+      <!-- Mobile Theme Toggle (hidden on desktop) -->
     <!--
       We remove the generic `theme-toggle` class here and use a unique class `theme-toggle-btn`.
       This prevents our mobile toggle from being hidden by legacy CSS rules targeting `.theme-toggle`.
@@ -191,27 +192,27 @@
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
       </svg>
     </button>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
+      <nav class="dng-links" aria-label="Hauptnavigation"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
 <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
   <!-- Sonne (outline) -->
   <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
   </svg>
-<!-- Mond Outline -->
-<svg class="icon moon" xmlns="http://www.w3.org/2000/svg" 
-     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" 
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 12.79A9 9 0 1 1 11.21 3 
-           7 7 0 0 0 21 12.79z"/>
-</svg>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
 </button>
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
-      <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+      <button id="dngNavToggle" class="dng-burger" aria-expanded="false" aria-controls="dngMobileMenu" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <div id="dngOverlay" class="dng-overlay" hidden></div>
+  <aside id="dngMobileMenu" class="dng-drawer" hidden aria-label="Mobile Navigation"><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -316,18 +317,9 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
-  <script>
-    (function(){
-      const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;
-      const open=()=>{menu.removeAttribute('hidden');btn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';};
-      const close=()=>{menu.setAttribute('hidden','');btn.setAttribute('aria-expanded','false');document.body.style.overflow='';};
-      btn.addEventListener('click',()=>btn.getAttribute('aria-expanded')==='true'?close():open());
-      document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
-      menu.querySelectorAll('a').forEach(a=>a.addEventListener('click',close));
-    })();
-  </script>
-    <script src="../js/theme.js" defer></script>
-      <div id="cookieBanner"></div>
+  <script src="../js/mobile.js" defer></script>
+  <script src="../js/theme.js" defer></script>
+  <div id="cookieBanner"></div>
   <!-- Cookie banner script: relative path corrected to parent js folder -->
   <script src="../js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/blog/bloguebersicht.html
+++ b/frontend/blog/bloguebersicht.html
@@ -1162,15 +1162,17 @@ html[data-theme="light"] .trustpilot-dark a {
 }
 
   </style>
+  <link rel="stylesheet" href="../css/theme.css">
 </head>
 <body>
   <!-- Header -->
-  <header class="dng-header">
-    <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html">
+  <header class="dng-header" data-mobile>
+    <div class="dng-container dng-nav">
+      <a class="dng-brand" href="../index.html" aria-label="DropNGo Startseite">
         <img class="dng-logo" src="../favicon.ico" alt="">
-        <span>DropNGo</span>
-         <!-- Mobile Theme Toggle (hidden on desktop) -->
+        <span class="dng-brand-text">DropNGo</span>
+      </a>
+      <!-- Mobile Theme Toggle (hidden on desktop) -->
     <!--
       We remove the generic `theme-toggle` class here and use a unique class `theme-toggle-btn`.
       This prevents our mobile toggle from being hidden by legacy CSS rules targeting `.theme-toggle`.
@@ -1188,8 +1190,7 @@ html[data-theme="light"] .trustpilot-dark a {
       </svg>
     </button>
 
-      </a>
-      <nav class="nav__links" aria-label="Hauptnavigation">
+      <nav class="dng-links" aria-label="Hauptnavigation">
         <a href="../index.html">Home</a>
         <a href="../products.html">Produkte</a>
         <a href="./bloguebersicht.html" aria-current="page">Blog</a>
@@ -1211,18 +1212,18 @@ html[data-theme="light"] .trustpilot-dark a {
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
-      <button id="navToggle" aria-expanded="false" aria-controls="mobileMenu" aria-label="Menü öffnen">
+      <button id="dngNavToggle" class="dng-burger" aria-expanded="false" aria-controls="dngMobileMenu" aria-label="Menü öffnen">
         <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
       </button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden>
+  <div id="dngOverlay" class="dng-overlay" hidden></div>
+  <aside id="dngMobileMenu" class="dng-drawer" hidden aria-label="Mobile Navigation">
     <nav class="dng-drawer-nav">
       <a href="../index.html">Home</a>
       <a href="../products.html">Produkte</a>
       <a href="./bloguebersicht.html" aria-current="page">Blog</a>
       <a href="../info.html">Über uns</a>
-     <!---- <a href="../support-formular.html">Support</a> -->
     </nav>
   </aside>
 
@@ -1444,6 +1445,8 @@ html[data-theme="light"] .trustpilot-dark a {
     });
   })();
 </script>
+<script src="../js/mobile.js" defer></script>
+<script src="../js/theme.js" defer></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   return; // deaktiviert das alte pressed-Script

--- a/frontend/blog/glueckstoff-orthopaedisches-kissen.html
+++ b/frontend/blog/glueckstoff-orthopaedisches-kissen.html
@@ -172,9 +172,10 @@
    <link rel="stylesheet" href="../css/theme.css">
 </head>
 <body>
-  <header class="dng-header">
-    <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>   <!-- Mobile Theme Toggle (hidden on desktop) -->
+  <header class="dng-header" data-mobile>
+    <div class="dng-container dng-nav">
+      <a class="dng-brand" href="../index.html" aria-label="DropNGo Startseite"><img class="dng-logo" src="../favicon.ico" alt=""><span class="dng-brand-text">DropNGo</span></a>
+      <!-- Mobile Theme Toggle (hidden on desktop) -->
     <!--
       We remove the generic `theme-toggle` class here and use a unique class `theme-toggle-btn`.
       This prevents our mobile toggle from being hidden by legacy CSS rules targeting `.theme-toggle`.
@@ -191,27 +192,27 @@
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
       </svg>
     </button>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
+      <nav class="dng-links" aria-label="Hauptnavigation"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
 <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
   <!-- Sonne (outline) -->
   <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
   </svg>
-<!-- Mond Outline -->
-<svg class="icon moon" xmlns="http://www.w3.org/2000/svg" 
-     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" 
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 12.79A9 9 0 1 1 11.21 3 
-           7 7 0 0 0 21 12.79z"/>
-</svg>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
 </button>
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
-      <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+      <button id="dngNavToggle" class="dng-burger" aria-expanded="false" aria-controls="dngMobileMenu" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <div id="dngOverlay" class="dng-overlay" hidden></div>
+  <aside id="dngMobileMenu" class="dng-drawer" hidden aria-label="Mobile Navigation"><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -316,18 +317,9 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
-  <script>
-    (function(){
-      const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;
-      const open=()=>{menu.removeAttribute('hidden');btn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';};
-      const close=()=>{menu.setAttribute('hidden','');btn.setAttribute('aria-expanded','false');document.body.style.overflow='';};
-      btn.addEventListener('click',()=>btn.getAttribute('aria-expanded')==='true'?close():open());
-      document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
-      menu.querySelectorAll('a').forEach(a=>a.addEventListener('click',close));
-    })();
-  </script>
-    <script src="../js/theme.js" defer></script>
-      <div id="cookieBanner"></div>
+  <script src="../js/mobile.js" defer></script>
+  <script src="../js/theme.js" defer></script>
+  <div id="cookieBanner"></div>
   <!-- Cookie banner script: relative path corrected to parent js folder -->
   <script src="../js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/blog/sanotact-elektrolyte.html
+++ b/frontend/blog/sanotact-elektrolyte.html
@@ -172,9 +172,10 @@
    <link rel="stylesheet" href="../css/theme.css">
 </head>
 <body>
-  <header class="dng-header">
-    <div class="container dng-nav">
-      <a class="dng-brand" href="../index.html"><img class="dng-logo" src="../favicon.ico" alt=""><span>DropNGo</span></a>   <!-- Mobile Theme Toggle (hidden on desktop) -->
+  <header class="dng-header" data-mobile>
+    <div class="dng-container dng-nav">
+      <a class="dng-brand" href="../index.html" aria-label="DropNGo Startseite"><img class="dng-logo" src="../favicon.ico" alt=""><span class="dng-brand-text">DropNGo</span></a>
+      <!-- Mobile Theme Toggle (hidden on desktop) -->
     <!--
       We remove the generic `theme-toggle` class here and use a unique class `theme-toggle-btn`.
       This prevents our mobile toggle from being hidden by legacy CSS rules targeting `.theme-toggle`.
@@ -191,27 +192,27 @@
         <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
       </svg>
     </button>
-      <nav class="nav__links"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
+      <nav class="dng-links" aria-label="Hauptnavigation"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a>  <!-- Desktop Theme Toggle (hidden on mobile) -->
 <button id="themeToggleDesktop" class="theme-toggle-btn" aria-label="Theme umschalten">
   <!-- Sonne (outline) -->
   <svg class="icon sun" viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
     <circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
   </svg>
-<!-- Mond Outline -->
-<svg class="icon moon" xmlns="http://www.w3.org/2000/svg" 
-     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" 
+  <!-- Mond Outline -->
+  <svg class="icon moon" xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor"
      stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M21 12.79A9 9 0 1 1 11.21 3 
-           7 7 0 0 0 21 12.79z"/>
-</svg>
+    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+  </svg>
 </button>
   <!-- <a href="support-formular.html">Support</a> -->
   <!-- <a href="account.html" class="dng-account">Mein Konto</a> -->
 </nav>
-      <button id="navToggle" aria-controls="mobileMenu" aria-expanded="false" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" width="22" height="22"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
+      <button id="dngNavToggle" class="dng-burger" aria-expanded="false" aria-controls="dngMobileMenu" aria-label="Menü öffnen"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>
     </div>
   </header>
-  <aside id="mobileMenu" hidden><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a><!-- <a href="../support-formular.html">Support</a></nav> --></aside>
+  <div id="dngOverlay" class="dng-overlay" hidden></div>
+  <aside id="dngMobileMenu" class="dng-drawer" hidden aria-label="Mobile Navigation"><nav class="dng-drawer-nav"><a href="../index.html">Home</a><a href="../products.html">Produkte</a><a href="./bloguebersicht.html">Blog</a><a href="../info.html">Über uns</a></nav></aside>
 
   <main class="container">
     <article class="article">
@@ -312,18 +313,9 @@
     <div class="container copyright">© 2025 DropNGo – Alle Rechte vorbehalten.</div>
   </footer>
 
-  <script>
-    (function(){
-      const btn=document.getElementById('navToggle'); const menu=document.getElementById('mobileMenu'); if(!btn||!menu) return;
-      const open=()=>{menu.removeAttribute('hidden');btn.setAttribute('aria-expanded','true');document.body.style.overflow='hidden';};
-      const close=()=>{menu.setAttribute('hidden','');btn.setAttribute('aria-expanded','false');document.body.style.overflow='';};
-      btn.addEventListener('click',()=>btn.getAttribute('aria-expanded')==='true'?close():open());
-      document.addEventListener('keydown',e=>{if(e.key==='Escape') close();});
-      menu.querySelectorAll('a').forEach(a=>a.addEventListener('click',close));
-    })();
-  </script>
-    <script src="../js/theme.js" defer></script>
-      <div id="cookieBanner"></div>
+  <script src="../js/mobile.js" defer></script>
+  <script src="../js/theme.js" defer></script>
+  <div id="cookieBanner"></div>
   <!-- Cookie banner script: relative path corrected to parent js folder -->
   <script src="../js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/css/theme.css
+++ b/frontend/css/theme.css
@@ -4,6 +4,26 @@
 .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15);}
 .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff;}
 .theme-toggle-btn .icon{display:none;}
+/* Ensure toggles sit above other elements and remain clickable */
+#themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto;}
+/* Burger icon colors for light/dark themes */
+html[data-theme="light"] .dng-burger svg,
+html[data-theme="light"] .dng-burger svg path{stroke:#000!important;}
+html[data-theme="dark"] .dng-burger svg,
+html[data-theme="dark"] .dng-burger svg path{stroke:#e6e9ee!important;}
+/* Mobile menu background and link colors */
+html[data-theme="light"] .dng-drawer,
+html[data-theme="light"] #mobileMenu{background:#fff;color:#111;border-left:1px solid #e5e7eb;}
+html[data-theme="light"] .dng-drawer a,
+html[data-theme="light"] #mobileMenu a{color:#111;}
+html[data-theme="light"] .dng-drawer a:hover,
+html[data-theme="light"] #mobileMenu a:hover{background:#f5f6f7;}
+html[data-theme="dark"] .dng-drawer,
+html[data-theme="dark"] #mobileMenu{background:#0f172a;color:#e6e9ee;border-left:1px solid rgba(255,255,255,.12);}
+html[data-theme="dark"] .dng-drawer a,
+html[data-theme="dark"] #mobileMenu a{color:#e6e9ee;}
+html[data-theme="dark"] .dng-drawer a:hover,
+html[data-theme="dark"] #mobileMenu a:hover{background:rgba(255,255,255,.06);}
 html[data-theme="light"] .theme-toggle-btn .sun{display:block;}
 html[data-theme="dark"] .theme-toggle-btn .moon{display:block;}
 :root[data-theme="light"],html[data-theme="light"],body.light-mode{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--border:#e5e7eb;--surface-alt:#f7f7f7;}

--- a/frontend/datenschutz.html
+++ b/frontend/datenschutz.html
@@ -140,7 +140,7 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-    <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -410,7 +410,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
   <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/impressum.html
+++ b/frontend/impressum.html
@@ -141,7 +141,7 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-  <link rel="stylesheet" href="../css/theme.css">
+  <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -423,7 +423,7 @@
 </script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
   <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -399,7 +399,7 @@ html[data-theme="light"] .meta{
 }
 
   </style>
-  <link rel="stylesheet" href="../css/theme.css">
+  <link rel="stylesheet" href="css/theme.css">
   <!-- im <head> deiner index.html -->
 <link rel="stylesheet" href="css/launch.css">
 <meta name="color-scheme" content="dark">
@@ -1121,7 +1121,7 @@ html[data-theme="dark"] .theme-toggle-btn{
 
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
 <!-- irgendwo im Body, am besten ganz unten vor </body> -->
 <div id="cookieBanner"></div>
 <script src="js/cookie-banner.js" defer></script>


### PR DESCRIPTION
## Summary
- Align blog overview and posts with shared header markup so theme toggles no longer trigger index redirects
- Include global theme CSS and mobile menu scripts on blog pages to match info page styles and colors

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e619875c8321865e2d0a3fcb67aa