### PR TITLE
Fix mobile menu and theme toggle across pages

### DIFF
--- a/frontend/01-beurer-br-60-insektenstichheiler.html
+++ b/frontend/01-beurer-br-60-insektenstichheiler.html
@@ -298,7 +298,7 @@
     .hero-media img{ max-width:100%; max-height:400px; object-fit:contain; }
     .rel-card img{ width:90px; height:90px; object-fit:cover; }
   </style>
-   <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="css/theme.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -566,10 +566,9 @@
 <script defer src="js/account-slot.js"></script>        <!-- Pfad anpassen -->
 
 
-</script>
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
- <script src="../js/theme.js" defer></script>
+ <script src="js/theme.js" defer></script>
      <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/agb.html
+++ b/frontend/agb.html
@@ -141,7 +141,8 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-   <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="css/theme.css">
+   <link rel="stylesheet" href="css/mobile.css">
 </head>
 <body>
   <!-- ===== Global Header (neu) ===== -->
@@ -363,9 +364,8 @@
     menu.querySelectorAll('a').forEach(a => a.addEventListener('click', closeMenu));
   })();
 </script>
-<link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
 
   <!-- Cookie banner: placeholder and script injection -->
   <div id="cookieBanner"></div>

--- a/frontend/blog/beurer-br60-insektenstichheiler.html
+++ b/frontend/blog/beurer-br60-insektenstichheiler.html
@@ -170,6 +170,7 @@
 
   </style>
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/mobile.css">
 </head>
 <body>
   <header class="dng-header">

--- a/frontend/blog/bienengift-gelenkcreme.html
+++ b/frontend/blog/bienengift-gelenkcreme.html
@@ -170,6 +170,7 @@
 
   </style>
    <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="../css/mobile.css">
 </head>
 <body>
   <header class="dng-header">

--- a/frontend/blog/bloguebersicht.html
+++ b/frontend/blog/bloguebersicht.html
@@ -1161,7 +1161,9 @@ html[data-theme="light"] .trustpilot-dark a {
   border-radius: 8px;    /* optional kleine Rundung */
 }
 
-  </style>
+</style>
+  <link rel="stylesheet" href="../css/theme.css">
+  <link rel="stylesheet" href="../css/mobile.css">
 </head>
 <body>
   <!-- Header -->
@@ -1526,6 +1528,7 @@ document.addEventListener('DOMContentLoaded', () => {
   <!-- Cookie banner placeholder and script injection -->
   <div id="cookieBanner"></div>
   <!-- Cookie banner script: relative path corrected to parent js folder -->
+  <script src="../js/theme.js" defer></script>
   <script src="../js/cookie-banner.js" defer></script>
 </body>
 </html>

--- a/frontend/blog/glueckstoff-orthopaedisches-kissen.html
+++ b/frontend/blog/glueckstoff-orthopaedisches-kissen.html
@@ -170,6 +170,7 @@
 
   </style>
    <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="../css/mobile.css">
 </head>
 <body>
   <header class="dng-header">

--- a/frontend/blog/sanotact-elektrolyte.html
+++ b/frontend/blog/sanotact-elektrolyte.html
@@ -170,6 +170,7 @@
 
   </style>
    <link rel="stylesheet" href="../css/theme.css">
+   <link rel="stylesheet" href="../css/mobile.css">
 </head>
 <body>
   <header class="dng-header">

--- a/frontend/css/mobile.css
+++ b/frontend/css/mobile.css
@@ -17,7 +17,7 @@
   backdrop-filter:saturate(140%) blur(10px);
   background:rgba(12,15,19,.7); border-bottom:1px solid var(--dng-border);
 }
-.dng-nav{display:flex;align-items:center;justify-content:space-between;height:var(--dng-header-h);gap:12px}
+.dng-nav{display:flex;align-items:center;gap:12px;height:var(--dng-header-h);justify-content:flex-start}
 .dng-brand{display:flex;align-items:center;gap:10px;color:var(--dng-text);text-decoration:none}
 .dng-logo{width:34px;height:34px;border-radius:10px;box-shadow:0 6px 18px rgba(24,161,150,.25)}
 .dng-brand-text{font-weight:800}
@@ -29,10 +29,12 @@
 .dng-burger{
   display:none; width:40px;height:40px;border-radius:10px;
   border:1px solid var(--dng-border); background:transparent; color:var(--dng-text);
-  cursor:pointer; -webkit-tap-highlight-color:transparent;
+  cursor:pointer; -webkit-tap-highlight-color:transparent; margin-left:auto;
 }
 .dng-burger svg{width:22px;height:22px;display:block}
 .dng-burger svg path{stroke:currentColor}
+
+#navToggle{margin-left:auto}
 
 /* Overlay */
 .dng-overlay{

--- a/frontend/css/theme.css
+++ b/frontend/css/theme.css
@@ -4,6 +4,26 @@
 .theme-toggle-btn{display:flex;align-items:center;justify-content:center;width:44px;height:44px;border-radius:50%;border:none;cursor:pointer;background:var(--surface);color:var(--text);transition:background .3s,color .3s,transform .2s;box-shadow:0 4px 12px rgba(0,0,0,.15);}
 .theme-toggle-btn:hover{transform:scale(1.1);background:var(--brand);color:#fff;}
 .theme-toggle-btn .icon{display:none;}
+/* Ensure toggles sit above other elements and remain clickable */
+#themeToggleDesktop,#themeToggleMobile{position:relative;z-index:10;pointer-events:auto;}
+/* Burger icon colors for light/dark themes */
+html[data-theme="light"] .dng-burger svg,
+html[data-theme="light"] .dng-burger svg path{stroke:#000!important;}
+html[data-theme="dark"] .dng-burger svg,
+html[data-theme="dark"] .dng-burger svg path{stroke:#e6e9ee!important;}
+/* Mobile menu background and link colors */
+html[data-theme="light"] .dng-drawer,
+html[data-theme="light"] #mobileMenu{background:#fff;color:#111;border-left:1px solid #e5e7eb;}
+html[data-theme="light"] .dng-drawer a,
+html[data-theme="light"] #mobileMenu a{color:#111;}
+html[data-theme="light"] .dng-drawer a:hover,
+html[data-theme="light"] #mobileMenu a:hover{background:#f5f6f7;}
+html[data-theme="dark"] .dng-drawer,
+html[data-theme="dark"] #mobileMenu{background:rgba(9,11,12,.98);color:#e6e9ee;border-left:1px solid rgba(255,255,255,.12);}
+html[data-theme="dark"] .dng-drawer a,
+html[data-theme="dark"] #mobileMenu a{color:#e6e9ee;}
+html[data-theme="dark"] .dng-drawer a:hover,
+html[data-theme="dark"] #mobileMenu a:hover{background:rgba(255,255,255,.06);}
 html[data-theme="light"] .theme-toggle-btn .sun{display:block;}
 html[data-theme="dark"] .theme-toggle-btn .moon{display:block;}
 :root[data-theme="light"],html[data-theme="light"],body.light-mode{--bg:#ffffff;--surface:#ffffff;--elev:#f7f7f7;--text:#0f172a;--muted:#0f172a;--border:#e5e7eb;--surface-alt:#f7f7f7;}

--- a/frontend/datenschutz.html
+++ b/frontend/datenschutz.html
@@ -140,7 +140,8 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-    <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="css/theme.css">
+    <link rel="stylesheet" href="css/mobile.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -408,9 +409,8 @@
     menu.querySelectorAll('a').forEach(a => a.addEventListener('click', closeMenu));
   })();
 </script>
-<link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
   <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/impressum.html
+++ b/frontend/impressum.html
@@ -141,7 +141,8 @@
   .mobile-menu { z-index: 10002; pointer-events: auto; }
 }
   </style>
-  <link rel="stylesheet" href="../css/theme.css">
+  <link rel="stylesheet" href="css/theme.css">
+  <link rel="stylesheet" href="css/mobile.css">
 </head>
 <body>
 <!-- ===== Global Header (neu) ===== -->
@@ -421,9 +422,8 @@
     menu.querySelectorAll('a').forEach(a => a.addEventListener('click', closeMenu));
   })();
 </script>
-<link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
   <div id="cookieBanner"></div>
   <script src="js/cookie-banner.js" defer></script>
 </body>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -399,7 +399,7 @@ html[data-theme="light"] .meta{
 }
 
   </style>
-  <link rel="stylesheet" href="../css/theme.css">
+  <link rel="stylesheet" href="css/theme.css">
   <!-- im <head> deiner index.html -->
 <link rel="stylesheet" href="css/launch.css">
 <meta name="color-scheme" content="dark">
@@ -1121,7 +1121,7 @@ html[data-theme="dark"] .theme-toggle-btn{
 
 <link rel="stylesheet" href="css/mobile.css">
 <script src="js/mobile.js" defer></script>
-<script src="../js/theme.js" defer></script>
+<script src="js/theme.js" defer></script>
 <!-- irgendwo im Body, am besten ganz unten vor </body> -->
 <div id="cookieBanner"></div>
 <script src="js/cookie-banner.js" defer></script>


### PR DESCRIPTION
## Summary
- Align mobile navigation so theme toggle sits beside logo and burger floats right
- Load mobile styles on legal pages so burger button and light/dark switch position correctly
- Add shared theme resources to blog pages to stop redirects and ensure menu backgrounds match themes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e619875c8321865e2d0a3fcb67aa